### PR TITLE
Pin the CircleCI build to version 1.13.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     docker:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.13.1
 
     #### TEMPLATE_NOTE: go expects specific checkout path representing url
     #### expecting it in the form of


### PR DESCRIPTION
We also pin this exact version in the `Dockerfile`.