### PR TITLE
Copy internal package to docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go


### PR DESCRIPTION
The current build at HEAD is failing with

```
Step 9/14 : RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 ---> Running in 3df6873e34bd
go: finding github.com/improbable-eng/etcd-cluster-operator/internal latest
go: finding github.com/improbable-eng/etcd-cluster-operator/internal/etcdenvvar latest
build command-line-arguments: cannot load github.com/improbable-eng/etcd-cluster-operator/internal/etcdenvvar: no matching versions for query "latest"
```

this is because we do not copy `internal/` in to the container build context. 

the docker build succeeds after applying this fix.

```
Successfully built 2a8a23ab3291
Successfully tagged etcd-operator:latest
```