### PR TITLE
Run e2e tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,9 @@ jobs:
           name: Install Go
           command: |
             sudo rm -rf /usr/local/go
-            curl -sSL "https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/
+            curl -sSL "https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz" -o go.tar.gz 
+            echo "94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124  go.tar.gz" | sha256sum -c
+            sudo tar -xzf go.tar.gz -C /usr/local/
             echo "export PATH=$PATH:/usr/local/go/bin" >> $BASH_ENV
             echo 'export GOPATH=$HOME/go' >> $BASH_ENV 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
           name: Install Go
           command: |
             sudo rm -rf /usr/local/go
-            curl -sSL "https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz" -o go.tar.gz 
-            echo "94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124  go.tar.gz" | sha256sum -c
-            sudo tar -xzf go.tar.gz -C /usr/local/
+            curl -sSL "https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz" -o /tmp/go.tar.gz 
+            echo "94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124  /tmp/go.tar.gz" | sha256sum -c
+            sudo tar -xzf /tmp/go.tar.gz -C /usr/local/
             echo "export PATH=$PATH:/usr/local/go/bin" >> $BASH_ENV
             echo 'export GOPATH=$HOME/go' >> $BASH_ENV 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,9 @@ jobs:
       - run:
           name: Install kubectl
           command: |
-            # Get latest kubectl release
-            KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-            # Download kubectl 
-            curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
+            # Download & verify kubectl 
+            curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.2/bin/linux/amd64/kubectl
+            echo "3ff48e12f9c768ad548e4221d805281ea28dfcda5c18b3cd1797fe37aee3012e  kubectl" | sha256sum -c 
             # Mark it executable & move to /bin
             sudo chmod +x ./kubectl
             sudo mv ./kubectl /usr/local/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,17 +4,31 @@
 version: 2
 jobs:
   build:
-    docker:
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/golang:1.13.1
-
-    #### TEMPLATE_NOTE: go expects specific checkout path representing url
-    #### expecting it in the form of
-    ####   /go/src/github.com/circleci/go-tool
-    ####   /go/src/bitbucket.org/circleci/go-tool
-    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    machine:
+      image: circleci/classic:latest
+    working_directory: ~/go/src/github.com/improbable-eng/etcd-cluster-operator
     steps:
+      - run:
+          name: Install Go
+          command: |
+            sudo rm -rf /usr/local/go
+            curl -sSL "https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/
+            echo "export PATH=$PATH:/usr/local/go/bin" >> $BASH_ENV
+            echo 'export GOPATH=$HOME/go' >> $BASH_ENV 
+      - run:
+          name: Install kubectl
+          command: |
+            # Get latest kubectl release
+            KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+            # Download kubectl 
+            curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
+            # Mark it executable & move to /bin
+            sudo chmod +x ./kubectl
+            sudo mv ./kubectl /usr/local/bin
       - checkout
-
-      - run: make test
+      - run: 
+         name: Unit tests
+         command: make test
+      - run:
+         name: End to end tests
+         command: make e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,4 +31,4 @@ jobs:
          command: make test
       - run:
          name: End to end tests
-         command: make e2e
+         command: make kind

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,11 @@ all: manager
 bin/kubebuilder:
 	hack/download-kubebuilder-local.sh
 
-# Run tests
+# Run unit tests
 test: generate fmt vet manifests bin/kubebuilder
 	KUBEBUILDER_ASSETS="$(shell pwd)/bin/kubebuilder/bin" go test ./... -coverprofile cover.out
 
+# Run end to end tests in a local Kind cluster
 kind: generate fmt vet manifests
 	go test ./internal/test/e2e --kind --repo-root ${CURDIR} -v
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ test: generate fmt vet manifests bin/kubebuilder
 #  a) speed up the test run time slightly
 #  b) allow debug sessions to be attached to figure out what caused failures
 kind: generate fmt vet manifests
-	echo ${CLEANUP}
 	go test ./internal/test/e2e --kind --repo-root ${CURDIR} -v --cleanup=${CLEANUP}
 
 # Build manager binary

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,11 @@ bin/kubebuilder:
 test: generate fmt vet manifests bin/kubebuilder
 	KUBEBUILDER_ASSETS="$(shell pwd)/bin/kubebuilder/bin" go test ./... -coverprofile cover.out
 
-# Run end to end tests in a local Kind cluster
+# Run end to end tests in a local Kind cluster. We do not clean up after running the tests to
+#  a) speed up the test run time slightly
+#  b) allow debug sessions to be attached to figure out what caused failures
 kind: generate fmt vet manifests
-	go test ./internal/test/e2e --kind --repo-root ${CURDIR} -v
+	go test ./internal/test/e2e --kind --repo-root ${CURDIR} -v --cleanup=false
 
 # Build manager binary
 manager: generate fmt vet

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+ifeq ($(CIRCLECI),"true")
+CLEANUP="false"
+else
+CLEANUP="true"
+endif
+
 all: manager
 
 # Get binary dependencies
@@ -25,7 +31,8 @@ test: generate fmt vet manifests bin/kubebuilder
 #  a) speed up the test run time slightly
 #  b) allow debug sessions to be attached to figure out what caused failures
 kind: generate fmt vet manifests
-	go test ./internal/test/e2e --kind --repo-root ${CURDIR} -v --cleanup=false
+	echo ${CLEANUP}
+	go test ./internal/test/e2e --kind --repo-root ${CURDIR} -v --cleanup=${CLEANUP}
 
 # Build manager binary
 manager: generate fmt vet


### PR DESCRIPTION
the build will fail until master is fixed, but this branch aims to tie the e2e tests in to our circle CI build.

as written, this replaces the docker executer we're using with a machine type. this may cause tests to run slightly slower but i don't think it's possible to expose ports to a host in circle ci's docker executers. 

see #7 

