### PR TITLE
Fix hack/verify on macOS

### DIFF
--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -8,6 +8,8 @@ projectdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 cd "${projectdir}"
 
+# Use short form arguments here to support BSD/macOS. `-d` instructs
+# it to make a directory, `-t` provides a prefix to use for the directory name.
 tmp="$(mktemp -d -t verify.sh.XXXXXXXX)"
 
 cleanup() {

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -8,7 +8,7 @@ projectdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 cd "${projectdir}"
 
-tmp="$(mktemp --directory --tmpdir verify.sh.XXXXXXXX)"
+tmp="$(mktemp -d -t verify.sh.XXXXXXXX)"
 
 cleanup() {
     rm -rf "${tmp}"


### PR DESCRIPTION
before:
```
» make verify       
./hack/verify.sh make -s gomod
mktemp: illegal option -- -
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix
make: *** [verify-gomod] Error 1
```

macOS's `mktemp` appears to not support long-form arguments. switching to the shorthands fixes this.