### PR TITLE
Mark Kubebuilder generated files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+api/*/zz_generated.deepcopy.go linguist-generated=true
+config/crd/bases/*.yaml linguist-generated=true
+config/rbac/role.yaml linguist-generated=true


### PR DESCRIPTION
This will [mark some files as auto-generated](https://help.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github), such that GitHub will automatically collapse them in Pull Request diffs.

```
$ git check-attr --all -- api/v1alpha1/*.go
api/v1alpha1/zz_generated.deepcopy.go: linguist-generated: true

$ git check-attr --all -- config/crd/bases/*
config/crd/bases/etcd.improbable.io_etcdclusters.yaml: linguist-generated: true
config/crd/bases/etcd.improbable.io_etcdpeers.yaml: linguist-generated: true

$ git check-attr --all -- config/rbac/*.yaml
config/rbac/role.yaml: linguist-generated: true
```