### PR TITLE
E2E persistence tests

### DIFF
--- a/config/samples/etcd_v1alpha1_etcdcluster.yaml
+++ b/config/samples/etcd_v1alpha1_etcdcluster.yaml
@@ -2,7 +2,6 @@ apiVersion: etcd.improbable.io/v1alpha1
 kind: EtcdCluster
 metadata:
   name: my-cluster
-  namespace: default
 spec:
   replicas: 3
   storage:

--- a/config/test/e2e/persistence/cluster.yaml
+++ b/config/test/e2e/persistence/cluster.yaml
@@ -1,0 +1,12 @@
+apiVersion: etcd.improbable.io/v1alpha1
+kind: EtcdCluster
+metadata:
+  name: cluster1
+spec:
+  replicas: 1
+  storage:
+    volumeClaimTemplate:
+      storageClassName: standard
+      resources:
+        requests:
+          storage: 50Mi

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -12,9 +12,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
@@ -186,10 +188,17 @@ func defineReplicaSet(peer etcdv1alpha1.EtcdPeer) appsv1.ReplicaSet {
 }
 
 func pvcForPeer(peer *etcdv1alpha1.EtcdPeer) *corev1.PersistentVolumeClaim {
+	labels := map[string]string{
+		appLabel:     appName,
+		clusterLabel: peer.Spec.ClusterName,
+		peerLabel:    peer.Name,
+	}
+
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      peer.Name,
 			Namespace: peer.Namespace,
+			Labels:    labels,
 		},
 		Spec: *peer.Spec.Storage.VolumeClaimTemplate.DeepCopy(),
 	}
@@ -286,6 +295,34 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+type pvcMapper struct{}
+
+var _ handler.Mapper = &pvcMapper{}
+
+// Map looks up the peer name label from the PVC and generates a reconcile
+// request for *that* name in the namespace of the pvc.
+// This mapper ensures that we only wake up the Reconcile function for changes
+// to PVCs related to EtcdPeer resources.
+// PVCs are deliberately not owned by the peer, to ensure that they are not
+// garbage collected along with the peer.
+// So we can't use OwnerReference handler here.
+func (m *pvcMapper) Map(o handler.MapObject) []reconcile.Request {
+	requests := []reconcile.Request{}
+	labels := o.Meta.GetLabels()
+	if peerName, found := labels[peerLabel]; found {
+		requests = append(
+			requests,
+			reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      peerName,
+					Namespace: o.Meta.GetNamespace(),
+				},
+			},
+		)
+	}
+	return requests
+}
+
 func (r *EtcdPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&etcdv1alpha1.EtcdPeer{}).
@@ -293,6 +330,8 @@ func (r *EtcdPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.ReplicaSet{}).
 		// We can use a simple EnqueueRequestForObject handler here as the PVC
 		// has the same name as the EtcdPeer resource that needs to be enqueued
-		Watches(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, &handler.EnqueueRequestForObject{}).
+		Watches(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, &handler.EnqueueRequestsFromMapFunc{
+			ToRequests: &pvcMapper{},
+		}).
 		Complete(r)
 }

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -280,15 +280,18 @@ func TestE2E(t *testing.T) {
 	t.Run("Parallel", func(t *testing.T) {
 		t.Run("SampleCluster", func(t *testing.T) {
 			t.Parallel()
-			sampleClusterTests(t, kubectl.WithT(t), sampleClusterPath)
+			ns := NamespaceForTest(t, kubectl)
+			sampleClusterTests(t, kubectl.WithT(t).WithDefaultNamespace(ns), sampleClusterPath)
 		})
 		t.Run("Webhooks", func(t *testing.T) {
 			t.Parallel()
-			webhookTests(t, kubectl.WithT(t))
+			ns := NamespaceForTest(t, kubectl)
+			webhookTests(t, kubectl.WithT(t).WithDefaultNamespace(ns))
 		})
 		t.Run("Persistence", func(t *testing.T) {
 			t.Parallel()
-			persistenceTests(t, kubectl.WithT(t))
+			ns := NamespaceForTest(t, kubectl)
+			persistenceTests(t, kubectl.WithT(t).WithDefaultNamespace(ns))
 		})
 	})
 }
@@ -400,7 +403,7 @@ func sampleClusterTests(t *testing.T, kubectl *kubectlContext, sampleClusterPath
 		kubectl := kubectl.WithT(t)
 		err := try.Eventually(func() error {
 			t.Log("")
-			members, err := kubectl.Get("--namespace", "default", "etcdcluster", "my-cluster", "-o=jsonpath='{.status.members...name}'")
+			members, err := kubectl.Get("etcdcluster", "my-cluster", "-o=jsonpath='{.status.members...name}'")
 			if err != nil {
 				return err
 			}

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -467,6 +467,7 @@ func persistenceTests(t *testing.T, kubectl *kubectlContext) {
 		}
 		return nil
 	}, time.Minute, time.Second*5)
+	require.NoError(t, err)
 
 	t.Log("The cluster can be restored.")
 	err = kubectl.Apply("--filename", configPath)

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -435,7 +435,7 @@ func etcdctl(kubectl *kubectlContext, svcName string, args ...string) (string, e
 
 func persistenceTests(t *testing.T, kubectl *kubectlContext) {
 	t.Log("Given a 1-node cluster.")
-	configPath := filepath.Join(*fRepoRoot, "config/test/e2e/persistence")
+	configPath := filepath.Join(*fRepoRoot, "config", test", e2e", "persistence")
 	err := kubectl.Apply("--filename", configPath)
 	require.NoError(t, err)
 

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -435,7 +435,7 @@ func etcdctl(kubectl *kubectlContext, svcName string, args ...string) (string, e
 
 func persistenceTests(t *testing.T, kubectl *kubectlContext) {
 	t.Log("Given a 1-node cluster.")
-	configPath := filepath.Join(*fRepoRoot, "config", test", e2e", "persistence")
+	configPath := filepath.Join(*fRepoRoot, "config", "test", "e2e", "persistence")
 	err := kubectl.Apply("--filename", configPath)
 	require.NoError(t, err)
 

--- a/internal/test/e2e/fixtures/cluster-client-service.yaml
+++ b/internal/test/e2e/fixtures/cluster-client-service.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: my-cluster-external
-  namespace: default
 spec:
   type: NodePort
   selector:

--- a/internal/test/e2e/kubectl.go
+++ b/internal/test/e2e/kubectl.go
@@ -94,13 +94,13 @@ func (k *kubectlContext) DryRun(filename string) (string, error) {
 	return string(out), err
 }
 
-// Create wraps `kubectl create', returning the unparsed output & any error that occurred.
+// Create wraps `kubectl create', returning the unparsed output & any errors that occurred.
 func (k *kubectlContext) Create(args ...string) (string, error) {
 	out, err := k.do(append([]string{"create"}, args...)...)
 	return string(out), err
 }
 
-// Label wraps `kubectl create', returning the unparsed output & any error that occurred.
+// Label wraps `kubectl label', returning the unparsed output & any errors that occurred.
 func (k *kubectlContext) Label(args ...string) (string, error) {
 	out, err := k.do(append([]string{"label"}, args...)...)
 	return string(out), err
@@ -118,6 +118,8 @@ func (k *kubectlContext) WithT(t *testing.T) *kubectlContext {
 	}
 }
 
+// WithDefaultNamespace returns a kubectl where `--namespace ns` will be
+// prepended to all the other supplied arguments.
 func (k *kubectlContext) WithDefaultNamespace(ns string) *kubectlContext {
 	return &kubectlContext{
 		t:                k.t,
@@ -127,6 +129,11 @@ func (k *kubectlContext) WithDefaultNamespace(ns string) *kubectlContext {
 	}
 }
 
+// NamespaceForTest creates a new namespace with a name derived from the current
+// running test.
+// It adds a label, so that all such namespaces can easily be found.
+// And if a namespace with that label already exists, it deletes it first to
+// cleanup any resources left over from the previous test.
 func NamespaceForTest(t *testing.T, kubectl *kubectlContext) string {
 	testName := t.Name()
 	name := testName

--- a/internal/test/e2e/kubectl.go
+++ b/internal/test/e2e/kubectl.go
@@ -7,14 +7,19 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+const testNameLabelKey = "e2e.etcd.improbable.io/test-name"
 
 // kubectlContext wraps shell calls to `kubectl', appropriately handling their results. It is only intended for use
 // in tests.
 type kubectlContext struct {
-	t          *testing.T
-	configPath string
-	homeDir    string
+	t                *testing.T
+	configPath       string
+	homeDir          string
+	defaultNamespace *string
 }
 
 func (k *kubectlContext) do(args ...string) ([]byte, error) {
@@ -24,6 +29,10 @@ func (k *kubectlContext) do(args ...string) ([]byte, error) {
 			return nil, err
 		}
 		k.homeDir = hd
+	}
+
+	if k.defaultNamespace != nil {
+		args = append([]string{"--namespace", *k.defaultNamespace}, args...)
 	}
 
 	k.t.Log("Running kubectl " + strings.Join(args, " "))
@@ -85,13 +94,57 @@ func (k *kubectlContext) DryRun(filename string) (string, error) {
 	return string(out), err
 }
 
+// Create wraps `kubectl create', returning the unparsed output & any error that occurred.
+func (k *kubectlContext) Create(args ...string) (string, error) {
+	out, err := k.do(append([]string{"create"}, args...)...)
+	return string(out), err
+}
+
+// Label wraps `kubectl create', returning the unparsed output & any error that occurred.
+func (k *kubectlContext) Label(args ...string) (string, error) {
+	out, err := k.do(append([]string{"label"}, args...)...)
+	return string(out), err
+}
+
 // WithT returns a copy of k with a new testing context.
 // This ensures that messages logged with t.Log in this module are associated with the correct sub-test.
 // You should use this in any sub-test.
 func (k *kubectlContext) WithT(t *testing.T) *kubectlContext {
 	return &kubectlContext{
-		t:          t,
-		configPath: k.configPath,
-		homeDir:    k.homeDir,
+		t:                t,
+		configPath:       k.configPath,
+		homeDir:          k.homeDir,
+		defaultNamespace: k.defaultNamespace,
 	}
+}
+
+func (k *kubectlContext) WithDefaultNamespace(ns string) *kubectlContext {
+	return &kubectlContext{
+		t:                k.t,
+		configPath:       k.configPath,
+		homeDir:          k.homeDir,
+		defaultNamespace: &ns,
+	}
+}
+
+func NamespaceForTest(t *testing.T, kubectl *kubectlContext) string {
+	testName := t.Name()
+	name := testName
+	name = strings.ReplaceAll(name, "_", "-")
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ToLower(name)
+	label := fmt.Sprintf("%s=%s", testNameLabelKey, name)
+	t.Log("Deleting existing namespace (if present)")
+	err := kubectl.Delete("namespace", "--selector", label, "--wait")
+	require.NoError(t, err)
+
+	t.Log("Creating new namespace for test")
+	out, err := kubectl.Create("namespace", name)
+	require.NoError(t, err, out)
+
+	t.Log("Labelling namespace")
+	out, err = kubectl.Label("namespace", name, label)
+	require.NoError(t, err, out)
+
+	return name
 }


### PR DESCRIPTION
Part of #29 

* Don't set OwnerReference on  PVC to prevent it being garbage collected for the peer it belongs to.
* Test that etcd data can survive after the etcd process is restarted.
 * Create a 1-node cluster
 * Use etcdctl to add a key / value
 * Delete all the cluster pods
 * Use etcdctl to retrieve the value again.

Fixes: #50
