### PR TITLE
Update validation

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -30,7 +30,7 @@ func (o *EtcdCluster) ValidateDelete() error {
 	return allErrs.ToAggregate()
 }
 
-// ValidateCreate validates that only supported fields are changed
+// ValidateUpdate validates that only supported fields are changed
 func (o *EtcdCluster) ValidateUpdate(old runtime.Object) error {
 	oldO, ok := old.(*EtcdCluster)
 	if !ok {

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -1,6 +1,9 @@
 package v1alpha1
 
 import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -28,10 +31,19 @@ func (o *EtcdCluster) ValidateDelete() error {
 }
 
 // ValidateCreate validates that only supported fields are changed
-// TODO: Not yet implemented
 func (o *EtcdCluster) ValidateUpdate(old runtime.Object) error {
-	var allErrs field.ErrorList
-	return allErrs.ToAggregate()
+	oldO, ok := old.(*EtcdCluster)
+	if !ok {
+		return fmt.Errorf("Unexpected type for old: %#v", old)
+	}
+	oldO = oldO.DeepCopy()
+	// Overwrite the fields which are allowed to change
+	oldO.Spec.Replicas = o.Spec.Replicas
+
+	if diff := cmp.Diff(oldO.Spec, o.Spec); diff != "" {
+		return fmt.Errorf("Unsupported changes: (- current, + new) %s", diff)
+	}
+	return nil
 }
 
 var _ webhook.Validator = &EtcdPeer{}
@@ -56,10 +68,20 @@ func (o *EtcdPeer) ValidateDelete() error {
 }
 
 // ValidateCreate validates that only supported fields are changed
-// TODO: Not yet implemented
 func (o *EtcdPeer) ValidateUpdate(old runtime.Object) error {
-	var allErrs field.ErrorList
-	return allErrs.ToAggregate()
+	oldO, ok := old.(*EtcdPeer)
+	if !ok {
+		return fmt.Errorf("Unexpected type for old: %#v", old)
+	}
+	oldO = oldO.DeepCopy()
+
+	// Overwrite any the fields which are allowed to change
+	// oldO.Spec.Foo = o.Spec.Foo
+
+	if diff := cmp.Diff(oldO.Spec, o.Spec); diff != "" {
+		return fmt.Errorf("Unsupported changes: (- current, + new) %s", diff)
+	}
+	return nil
 }
 
 func validatePersistentVolumeClaimSpec(path *field.Path, o *corev1.PersistentVolumeClaimSpec) field.ErrorList {

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -37,6 +37,14 @@ func (o *EtcdCluster) ValidateUpdate(old runtime.Object) error {
 		return fmt.Errorf("Unexpected type for old: %#v", old)
 	}
 	oldO = oldO.DeepCopy()
+
+	if *oldO.Spec.Replicas > *o.Spec.Replicas {
+		return fmt.Errorf(
+			"Unsupported changes: spec.replicas: current: %d, new: %d: scale-in is not supported",
+			*oldO.Spec.Replicas, *o.Spec.Replicas,
+		)
+	}
+
 	// Overwrite the fields which are allowed to change
 	oldO.Spec.Replicas = o.Spec.Replicas
 

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -75,7 +75,7 @@ func (o *EtcdPeer) ValidateDelete() error {
 	return allErrs.ToAggregate()
 }
 
-// ValidateCreate validates that only supported fields are changed
+// ValidateUpdate validates that only supported fields are changed
 func (o *EtcdPeer) ValidateUpdate(old runtime.Object) error {
 	oldO, ok := old.(*EtcdPeer)
 	if !ok {

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -68,14 +68,21 @@ func TestEtcdCluster_ValidateUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "StorageClassNameChanged",
+			name: "UnsupportedChange/ScaleIn",
+			modifier: func(o *v1alpha1.EtcdCluster) {
+				*o.Spec.Replicas -= 1
+			},
+			err: "scale-in is not supported",
+		},
+		{
+			name: "UnsupportedChange/StorageClassName",
 			modifier: func(o *v1alpha1.EtcdCluster) {
 				*o.Spec.Storage.VolumeClaimTemplate.StorageClassName += "-changed"
 			},
 			err: `^Unsupported changes:`,
 		},
 		{
-			name: "ResourcesStorageChanged",
+			name: "UnsupportedChange/ResourcesStorage",
 			modifier: func(o *v1alpha1.EtcdCluster) {
 				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = resource.MustParse("1Mi")
 			},
@@ -87,6 +94,9 @@ func TestEtcdCluster_ValidateUpdate(t *testing.T) {
 			o2 := o1.DeepCopy()
 			tc.modifier(o2)
 			err := o2.ValidateUpdate(o1)
+			if err != nil {
+				t.Log(err)
+			}
 			if tc.err != "" {
 				assert.Regexp(t, tc.err, err, "unexpected error message")
 			} else {
@@ -149,14 +159,14 @@ func TestEtcdPeer_ValidateUpdate(t *testing.T) {
 		err      string
 	}{
 		{
-			name: "StorageClassNameChanged",
+			name: "UnsupportedChange/StorageClassName",
 			modifier: func(o *v1alpha1.EtcdPeer) {
 				*o.Spec.Storage.VolumeClaimTemplate.StorageClassName += "-changed"
 			},
 			err: `^Unsupported changes:`,
 		},
 		{
-			name: "ResourcesStorageChanged",
+			name: "UnsupportedChange/ResourcesStorage",
 			modifier: func(o *v1alpha1.EtcdPeer) {
 				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = resource.MustParse("1Mi")
 			},
@@ -168,6 +178,9 @@ func TestEtcdPeer_ValidateUpdate(t *testing.T) {
 			o2 := o1.DeepCopy()
 			tc.modifier(o2)
 			err := o2.ValidateUpdate(o1)
+			if err != nil {
+				t.Log(err)
+			}
 			if tc.err != "" {
 				assert.Regexp(t, tc.err, err, "unexpected error message")
 			} else {

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
 	"github.com/improbable-eng/etcd-cluster-operator/internal/test"
 )
 
@@ -50,6 +52,51 @@ func TestEtcdCluster_ValidateCreate(t *testing.T) {
 	})
 }
 
+// TODO Incomplete.
+// Need to test changes for all PVC fields.
+// Ideally without exhaustively testing them all here.
+func TestEtcdCluster_ValidateUpdate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		modifier func(*v1alpha1.EtcdCluster)
+		err      string
+	}{
+		{
+			name: "ScaleOut",
+			modifier: func(o *v1alpha1.EtcdCluster) {
+				*o.Spec.Replicas += 1
+			},
+		},
+		{
+			name: "StorageClassNameChanged",
+			modifier: func(o *v1alpha1.EtcdCluster) {
+				*o.Spec.Storage.VolumeClaimTemplate.StorageClassName += "-changed"
+			},
+			err: `^Unsupported changes:`,
+		},
+		{
+			name: "ResourcesStorageChanged",
+			modifier: func(o *v1alpha1.EtcdCluster) {
+				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = resource.MustParse("1Mi")
+			},
+			err: `^Unsupported changes:`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			o1 := test.ExampleEtcdCluster("ns1")
+			o2 := o1.DeepCopy()
+			tc.modifier(o2)
+			err := o2.ValidateUpdate(o1)
+			if tc.err != "" {
+				assert.Regexp(t, tc.err, err, "unexpected error message")
+			} else {
+				assert.NoError(t, err, "unexpected error")
+			}
+		})
+	}
+
+}
+
 func TestEtcdPeer_ValidateCreate(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		o := test.ExampleEtcdPeer("ns1")
@@ -90,4 +137,43 @@ func TestEtcdPeer_ValidateCreate(t *testing.T) {
 			t.Log(err)
 		}
 	})
+}
+
+// TODO Incomplete.
+// Need to test changes for all PVC fields.
+// Ideally without exhaustively testing them all here.
+func TestEtcdPeer_ValidateUpdate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		modifier func(*v1alpha1.EtcdPeer)
+		err      string
+	}{
+		{
+			name: "StorageClassNameChanged",
+			modifier: func(o *v1alpha1.EtcdPeer) {
+				*o.Spec.Storage.VolumeClaimTemplate.StorageClassName += "-changed"
+			},
+			err: `^Unsupported changes:`,
+		},
+		{
+			name: "ResourcesStorageChanged",
+			modifier: func(o *v1alpha1.EtcdPeer) {
+				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = resource.MustParse("1Mi")
+			},
+			err: `^Unsupported changes:`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			o1 := test.ExampleEtcdPeer("ns1")
+			o2 := o1.DeepCopy()
+			tc.modifier(o2)
+			err := o2.ValidateUpdate(o1)
+			if tc.err != "" {
+				assert.Regexp(t, tc.err, err, "unexpected error message")
+			} else {
+				assert.NoError(t, err, "unexpected error")
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
Fixes: #49 

* Only allow changes to the EtcdCluster.Spec.Replicas field
* Only allow Replicas to be increased (scale-out)