### PR TITLE
Run Circle CI jobs in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,23 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
-  build:
+  verify:
+    docker:
+      - image: circleci/golang:1.13.1
+    steps:
+      - checkout
+      - run:
+         name: Static checks
+         command: make verify
+  test:
+    docker:
+      - image: circleci/golang:1.13.1
+    steps:
+      - checkout
+      - run:
+         name: Unit tests
+         command: make test
+  e2e:
     machine:
       image: circleci/classic:latest
     working_directory: ~/go/src/github.com/improbable-eng/etcd-cluster-operator
@@ -28,11 +44,12 @@ jobs:
             sudo mv ./kubectl /usr/local/bin
       - checkout
       - run:
-         name: Static checks
-         command: make verify
-      - run:
-         name: Unit tests
-         command: make test
-      - run:
          name: End to end tests
          command: make kind
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - verify
+      - test
+      - e2e


### PR DESCRIPTION
Run verify and test in Docker environments,
in parallel with the E2E tests in the VM environment.

This gives us fast feedback if the verify or test steps fail.
And allows the E2E tests to get started faster.