### PR TITLE
Scale up clusters

### DIFF
--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -27,6 +27,12 @@ type EtcdMember struct {
 
 // EtcdClusterStatus defines the observed state of EtcdCluster
 type EtcdClusterStatus struct {
+	// Replicas is the number of etcd peer resources we are managing. This doesn't mean the number of pods that exist
+	// (as we may have just created a peer resource that doesn't have a pod yet, or the pod could be restarting), and it
+	// doesn't mean the number of members the etcd cluster has live, as pods may not be ready yet or network problems
+	// may mean the cluster has lost a member.
+	Replicas int32 `json:"replicas"`
+
 	// Members contains information about each member from the etcd cluster.
 	// +optional
 	Members []EtcdMember `json:"members"`
@@ -34,6 +40,7 @@ type EtcdClusterStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 
 // EtcdCluster is the Schema for the etcdclusters API
 type EtcdCluster struct {

--- a/api/v1alpha1/etcdpeer_types.go
+++ b/api/v1alpha1/etcdpeer_types.go
@@ -27,12 +27,26 @@ type StaticBootstrap struct {
 	InitialCluster []InitialClusterMember `json:"initialCluster,omitempty"`
 }
 
+const InitialClusterStateNew InitialClusterState = "New"
+const InitialClusterStateExisting InitialClusterState = "Existing"
+
+// +kubebuilder:validation:Enum=New;Existing
+type InitialClusterState string
+
 // Bootstrap contains bootstrap infromation for the peer to use.
 type Bootstrap struct {
 	// Static boostrapping requires that we know the network names of the
 	// other peers ahead of time.
 	// +optional
 	Static *StaticBootstrap `json:"static,omitempty"`
+
+	// This is passed through directly to the underlying etcd instance as the `ETCD_INITIAL_CLUSTER_STATE` envvar or
+	// `--initial-cluster-state` flag. Like all bootstrap instructions, this is ignored if the data directory already
+	// exists, which for us is if an underlying persistent volume already exists.
+	//
+	// When peers are created during bootstrapping of a new cluster this should be set to `New`. When adding peers to
+	// an existing cluster during a scale-up event this should be set to `Existing`.
+	InitialClusterState InitialClusterState `json:"initialClusterState"`
 }
 
 // EtcdPeerSpec defines the desired state of EtcdPeer

--- a/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
@@ -16,6 +16,9 @@ spec:
     singular: etcdcluster
   scope: ""
   subresources:
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
     status: {}
   validation:
     openAPIV3Schema:
@@ -191,6 +194,17 @@ spec:
                 - name
                 type: object
               type: array
+            replicas:
+              description: Replicas is the number of etcd peer resources we are managing.
+                This doesn't mean the number of pods that exist (as we may have just
+                created a peer resource that doesn't have a pod yet, or the pod could
+                be restarting), and it doesn't mean the number of members the etcd
+                cluster has live, as pods may not be ready yet or network problems
+                may mean the cluster has lost a member.
+              format: int32
+              type: integer
+          required:
+          - replicas
           type: object
       type: object
   version: v1alpha1

--- a/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
@@ -39,6 +39,19 @@ spec:
                 the etcd pods. As per the etcd documentation, etcd will ignore bootstrap
                 instructions if it already knows where it's peers are.
               properties:
+                initialClusterState:
+                  description: "This is passed through directly to the underlying
+                    etcd instance as the `ETCD_INITIAL_CLUSTER_STATE` envvar or `--initial-cluster-state`
+                    flag. Like all bootstrap instructions, this is ignored if the
+                    data directory already exists, which for us is if an underlying
+                    persistent volume already exists. \n When peers are created during
+                    bootstrapping of a new cluster this should be set to `New`. When
+                    adding peers to an existing cluster during a scale-up event this
+                    should be set to `Existing`."
+                  enum:
+                  - New
+                  - Existing
+                  type: string
                 static:
                   description: Static boostrapping requires that we know the network
                     names of the other peers ahead of time.
@@ -68,6 +81,8 @@ spec:
                       minItems: 1
                       type: array
                   type: object
+              required:
+              - initialClusterState
               type: object
             clusterName:
               description: The name of the etcd cluster that this peer should join.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -258,7 +258,7 @@ func (r *EtcdClusterReconciler) reconcile(
 		}
 
 		// Remove EtcdPeer resources which do not have members.
-		// TODO Implement scale-down
+		// TODO(#35) Implement scale-down
 
 		// If we've reached this point we're sure that the EtcdPeer resources in the cluster match the contents of the
 		// membership API. The next step is checking to see if we want to mutate the membership API of etcd to scale up

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -240,14 +240,10 @@ func (r *EtcdClusterReconciler) reconcile(
 			}
 			if !memberHasPeer {
 				// We have found a member without a peer. We should add an EtcdPeer resource for this member
-				peerName, err := peerNameForMember(member)
-				if err != nil {
-					return ctrl.Result{}, nil, err
-				}
 				log.V(1).Info(
 					"Found member in etcd's API that has no EtcdPeer resource representation, adding one.",
-					"member-name", peerName)
-				peer := peerForCluster(cluster, peerName)
+					"member-name", expectedPeerName)
+				peer := peerForCluster(cluster, expectedPeerName)
 				configureJoinExistingCluster(peer, cluster, *members)
 
 				if err := r.Create(ctx, peer); err != nil {

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -2,9 +2,10 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/errors"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -14,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,10 +72,10 @@ func headlessServiceForCluster(cluster *etcdv1alpha1.EtcdCluster) *v1.Service {
 }
 
 // updateStatus updates the EtcdCluster resource's status to be the current value of the cluster.
-func (r *EtcdClusterReconciler) updateStatus(
-	ctx context.Context,
+func (r *EtcdClusterReconciler) updateStatus(ctx context.Context,
 	cluster *etcdv1alpha1.EtcdCluster,
 	members *[]etcdclient.Member,
+	peers *etcdv1alpha1.EtcdPeerList,
 	reconcilerEvent reconcilerevent.ReconcilerEvent) error {
 
 	if members != nil {
@@ -84,29 +86,55 @@ func (r *EtcdClusterReconciler) updateStatus(
 				ID:   member.ID,
 			}
 		}
-
-		if err := r.Client.Status().Update(ctx, cluster); err != nil {
-			return err
+	} else {
+		if cluster.Status.Members == nil {
+			cluster.Status.Members = make([]etcdv1alpha1.EtcdMember, 0)
+		} else {
+			// In this case we don't have up-to date members for whatever reason, which could be a temporary disruption
+			// such as a network issue. But we also know the status on the resource already has a member list. So just
+			// leave that (stale) data where it is and don't change it.
 		}
 	}
+
+	cluster.Status.Replicas = int32(len(peers.Items))
+
+	if err := r.Client.Status().Update(ctx, cluster); err != nil {
+		return err
+	}
+
 	return nil
 }
 
+// reconcile (little r) does the 'dirty work' of deciding if we wish to perform an action upon the Kubernetes cluster to
+// match our desired state. We will always perform exactly one or zero actions. The intent is that when multiple actions
+// are required we will do only one, then requeue this function to perform the next one. This helps to keep the code
+// simple, as every 'go around' only performs a single change.
+//
+// We strictly use the term "member" to refer to an item in the etcd membership list, and "peer" to refer to an
+// EtcdPeer resource created by us that ultimately creates a pod running the etcd binary.
+//
+// In order to allow other parts of this operator to know what we've done, we return a `reconcilerevent.ReconcilerEvent`
+// that should describe to the rest of this codebase what we have done.
 func (r *EtcdClusterReconciler) reconcile(
 	ctx context.Context,
 	members *[]etcdclient.Member,
+	peers *etcdv1alpha1.EtcdPeerList,
 	cluster *etcdv1alpha1.EtcdCluster,
 ) (
 	ctrl.Result,
 	reconcilerevent.ReconcilerEvent,
-	error) {
-
+	error,
+) {
 	name := types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      cluster.Name,
 	}
 	log := r.Log.WithValues("cluster", name)
 
+	// The first port of call is to verify that the service exists. This service is headless, and is designed to provide
+	// the underlying etcd pods with a consistent network identity such that they can dial each other. It *can* be used
+	// for client access to etcd if a user desires, but users are also encouraged to create their own services for their
+	// client access if that is more convenient.
 	service := &v1.Service{}
 	if err := r.Get(ctx, name, service); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -121,35 +149,196 @@ func (r *EtcdClusterReconciler) reconcile(
 	}
 	log.V(2).Info("Service exists", "service", service.Name)
 
+	// There are two big branches of behaviour: Either we (the operator) can contact the etcd cluster, or we can't. If
+	// the `members` pointer is nil that means we were unsuccessful in our attempts to connect. Otherwise it indicates
+	// a list of existing members.
 	if members == nil {
-		peers := &etcdv1alpha1.EtcdPeerList{}
-		if err := r.List(ctx, peers, client.MatchingFields{clusterNameSpecField: cluster.Name}); err != nil {
-			return ctrl.Result{}, nil, fmt.Errorf("unable to list peers: %w", err)
-		}
-
+		// We don't have communication with the cluster. This could be for a number of reasons, for example:
+		//
+		// * The cluster isn't up yet because we've not yet made the peers (during bootstrapping)
+		// * Pod rescheduling due to node failure or administrator action has made the cluster non-quorate
+		// * Network disruption inside the Kubernetes cluster has prevented us from connecting
+		//
+		// We treat the member list from etcd as a canonical list of what members should exist, so without it we're
+		// unable to reconcile what peers we should create. Most of the cases listed above will be solved by outside
+		// action. Either a network disruption will heal, or the scheduler will reschedule etcd pods. So no action is
+		// required.
+		//
+		// Bootstrapping is a notable exception. We have to create our peer resources so that the pods will be created
+		// in the first place. Which for us presents a 'chicken-and-egg' problem. Our solution is to take special
+		// action during a bootstrapping situation. We can't accurately detect that the cluster has actually just been
+		// bootstrapped in a reliable way (e.g., searching for the creation time on the cluster resource we're
+		// reconciling). So our 'best effort' is to see if our desired peers is less than our actual peers. If so, we
+		// just create new peers with bootstrap instructions.
+		//
+		// This may mean that we take a 'strange' action in some cases, such as a network disruption during a scale-up
+		// event where we may add peers without first adding them to the etcd internal membership list (like we would
+		// during normal operation). However, this situation will eventually heal:
+		//
+		// 1. We incorrectly create a blank peer
+		// 2. The network split heals
+		// 3. The cluster rejects the peer as it doesn't know about it
+		// 4. The operator reconciles, and removes the peer that the membership list doesn't see
+		// 5. We enter the normal scale-up behaviour, adding the peer to the membership list *first*.
+		//
+		// We are also careful to never *remove* a peer in this 'no contact' state. So while we may erroneously add
+		// peers in some edge cases, we will never remove a peer without first confirming the action is correct with
+		// the cluster.
 		if cluster.Spec.Replicas != nil && int32(len(peers.Items)) < *cluster.Spec.Replicas {
-			// Create more peers
+			// We have fewer peers than our replicas, so create a new peer. We do this one at a time, so only make
+			// *one* peer.
 			peerName := nextAvailablePeerName(cluster, peers.Items)
-			log.V(1).Info("Insufficient peers for replicas, adding new peer",
+			log.V(1).Info(
+				"Insufficient peers for replicas and unable to contact etcd. Assuming we're bootstrapping adding new peer. (If we're not we'll heal this later.)",
 				"current-peers", len(peers.Items),
 				"desired-peers", cluster.Spec.Replicas,
 				"peer", peerName)
 			peer := peerForCluster(cluster, peerName)
+			configurePeerBootstrap(peer, cluster)
 			if err := r.Create(ctx, peer); err != nil {
 				return ctrl.Result{}, nil, fmt.Errorf("failed to create EtcdPeer %s: %w", peerName, err)
 			}
 			return ctrl.Result{}, &reconcilerevent.PeerCreatedEvent{Object: cluster, PeerName: peer.Name}, nil
+		} else {
+			// We can't contact the cluster, and we don't *think* we need more peers. So it's unsafe to take any
+			// action.
 		}
 	} else {
+		// In this branch we *do* have communication with the cluster, and have retrieved a list of members. We treat
+		// this list as canonical, and therefore reconciliation occurs in two cycles:
+		//
+		// 1. We reconcile the membership list to match our expected number of replicas (`spec.replicas`), adding
+		//    members one at a time until reaching the correct number.
+		// 2. We reconcile the number of peer resources to match the membership list.
+		//
+		// This 'two-tier' process may seem odd, but is designed to mirror etcd's operations guide for adding and
+		// removing members. During a scale-up, etcd itself expects that new peers will be announced to it *first* using
+		// the membership API, and then the etcd process started on the new machine. During a scale down the same is
+		// true, where the membership API should be told that a member is to be removed before it is shut down.
 		log.V(2).Info("Cluster communication established")
+
+		// We reconcile the peer resources against the membership list before changing the membership list. This is the
+		// opposite way around to what we just said. But is important. It means that if you perform a scale-up to five
+		// from three, we'll add the fourth node to the membership list, then add the peer for the fourth node *before*
+		// we consider adding the fifth node to the membership list.
+
+		// Add EtcdPeer resources for members that do not have one.
+		for _, member := range *members {
+			// Use this instead of member.Name. If we've just added the peer for this member then the member might not
+			// have that field set, so instead figure it out from the peerURL.
+			expectedPeerName, err := peerNameForMember(member)
+			if err != nil {
+				log.Error(err, "Found member with no identifiable name, unable to reconcile it, skipping")
+				continue
+			}
+			memberHasPeer := false
+			for _, peer := range peers.Items {
+				if expectedPeerName == peer.Name {
+					memberHasPeer = true
+					break
+				}
+			}
+			if !memberHasPeer {
+				// We have found a member without a peer. We should add an EtcdPeer resource for this member
+				peerName, err := peerNameForMember(member)
+				if err != nil {
+					return ctrl.Result{}, nil, err
+				}
+				log.V(1).Info(
+					"Found member in etcd's API that has no EtcdPeer resource representation, adding one.",
+					"member-name", peerName)
+				peer := peerForCluster(cluster, peerName)
+				configureJoinExistingCluster(peer, cluster, *members)
+
+				if err := r.Create(ctx, peer); err != nil {
+					return ctrl.Result{}, nil, fmt.Errorf("failed to create EtcdPeer %s: %w", peer.Name, err)
+				}
+				return ctrl.Result{}, &reconcilerevent.PeerCreatedEvent{Object: cluster, PeerName: peer.Name}, nil
+			}
+		}
+
+		// Remove EtcdPeer resources which do not have members.
+		// TODO Implement scale-down
+
+		// If we've reached this point we're sure that the EtcdPeer resources in the cluster match the contents of the
+		// membership API. The next step is checking to see if we want to mutate the membership API of etcd to scale up
+		// or down. However we don't want to do this unless the cluster has stabilised from a previous member addition.
+		if isAllMembersStable(*members) {
+			// It's finally time to see if we need to mutate the membership API to bring it in-line with our expected
+			// replicas. There are three cases, we have enough members, too few, or too many. The order we check these
+			// cases in is irrelevant as only one can possibly be true.
+			if *cluster.Spec.Replicas > int32(len(*members)) {
+				// There are too few members for the expected number of replicas. Add a new member.
+				peerName := nextAvailablePeerName(cluster, peers.Items)
+				peerURL := &url.URL{
+					Scheme: etcdScheme,
+					Host:   fmt.Sprintf("%s:%d", expectedURLForPeer(cluster, peerName), etcdPeerPort),
+				}
+				log.V(1).Info("Too few members for expected replica count, adding new member.",
+					"expected-replicas", *cluster.Spec.Replicas,
+					"actual-members", len(*members),
+					"peer-name", peerName,
+					"peer-url", peerURL)
+				member, err := r.addEtcdMember(ctx, cluster, peerURL.String())
+				if err != nil {
+					return ctrl.Result{}, nil, fmt.Errorf("failed to add new member %s: %w", peerName, err)
+				}
+				// Requeue, as we don't watch on the membership list. So we don't auto-detect the change we just made.
+				// TODO Implement custom watch on etcd membership API, and remove this requeue after member addition
+				return ctrl.Result{RequeueAfter: time.Second * 10}, &reconcilerevent.MemberAddedEvent{Object: cluster, Member: member}, nil
+			} else if *cluster.Spec.Replicas < int32(len(*members)) {
+				// There are too many members for the expected number of replicas. Remove the member with the highest
+				// ordinal
+				// TODO Implement scale-down
+			} else {
+				// Exactly the correct number of members. Make no change, all is well with the world.
+				log.V(2).Info("Expected number of replicas aligned with actual number.",
+					"expected-replicas", *cluster.Spec.Replicas,
+					"actual-members", len(*members))
+			}
+		}
 	}
+	// This is the fall-through 'all is right with the world' case. We requeue here with a ten second timeout. This is
+	// so that we can recheck the membership API. We currently do not implement any watch on the etcd API, and as it is
+	// not a Kubernetes API we will have to implement one custom.
+
+	// TODO Implement custom watch on etcd membership API, and remove this regular requeue
 	return ctrl.Result{RequeueAfter: time.Second * 10}, nil, nil
+}
+
+func isAllMembersStable(members []etcdclient.Member) bool {
+	// We define 'stable' as 'has ever connected', which we detect by looking for the name on the member
+	for _, member := range members {
+		if member.Name == "" {
+			// No name, means it's not up, so the cluster isn't stable.
+			return false
+		}
+	}
+	// Didn't find any members with no name, so stable.
+	return true
+}
+
+func peerNameForMember(member etcdclient.Member) (string, error) {
+	if member.Name != "" {
+		return member.Name, nil
+	} else if len(member.PeerURLs) > 0 {
+		// Just take the first
+		peerURL := member.PeerURLs[0]
+		u, err := url.Parse(peerURL)
+		if err != nil {
+			return "", err
+		}
+		return strings.Split(u.Host, ".")[0], nil
+	} else {
+		return "", errors.New("nothing on member that could give a name")
+	}
 }
 
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *EtcdClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -181,9 +370,15 @@ func (r *EtcdClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		members = &memberSlice
 	}
 
-	// Perform a reconcile, getting back the desired result, any errors, and a clusterEvent. This is an internal concept
+	// List peers
+	peers := &etcdv1alpha1.EtcdPeerList{}
+	if err := r.List(ctx, peers, client.MatchingFields{clusterNameSpecField: cluster.Name}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to list peers: %w", err)
+	}
+
+	// Perform a reconcile, getting back the desired result, any utilerrors, and a clusterEvent. This is an internal concept
 	// and is not the same as the Kubernetes event, although it is used to make one later.
-	result, clusterEvent, reconcileErr := r.reconcile(ctx, members, cluster)
+	result, clusterEvent, reconcileErr := r.reconcile(ctx, members, peers, cluster)
 	if reconcileErr != nil {
 		log.Error(reconcileErr, "Failed to reconcile")
 	}
@@ -191,7 +386,7 @@ func (r *EtcdClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	// The update status takes in the cluster definition, and the member list from etcd as of *before we ran reconcile*.
 	// We also get the event, which may contain rich information about what we did (such as the new member name on a
 	// MemberAdded event).
-	updateStatusErr := r.updateStatus(ctx, cluster, members, clusterEvent)
+	updateStatusErr := r.updateStatus(ctx, cluster, members, peers, clusterEvent)
 	if updateStatusErr != nil {
 		log.Error(updateStatusErr, "Failed to update status")
 	}
@@ -201,7 +396,18 @@ func (r *EtcdClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		clusterEvent.Record(r.Recorder)
 	}
 
-	return result, errors.NewAggregate([]error{reconcileErr, updateStatusErr})
+	return result, utilerrors.NewAggregate([]error{reconcileErr, updateStatusErr})
+}
+
+func (r *EtcdClusterReconciler) addEtcdMember(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster, peerURL string) (*etcdclient.Member, error) {
+	etcdConfig := etcdClientConfig(cluster)
+	c, err := etcdclient.New(*etcdConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to etcd: %w", err)
+	}
+
+	membersAPI := etcdclient.NewMembersAPI(c)
+	return membersAPI.Add(ctx, peerURL)
 }
 
 func (r *EtcdClusterReconciler) getEtcdMembers(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster) ([]etcdclient.Member, error) {
@@ -248,13 +454,27 @@ func peerForCluster(cluster *etcdv1alpha1.EtcdCluster, peerName string) *etcdv1a
 		},
 		Spec: etcdv1alpha1.EtcdPeerSpec{
 			ClusterName: cluster.Name,
-			Bootstrap: &etcdv1alpha1.Bootstrap{
-				Static: &etcdv1alpha1.StaticBootstrap{
-					InitialCluster: initialClusterMembers(cluster),
-				},
-			},
-			Storage: cluster.Spec.Storage.DeepCopy(),
+			Storage:     cluster.Spec.Storage.DeepCopy(),
 		},
+	}
+}
+
+// configurePeerBootstrap is used during *cluster* bootstrap to configure the peers to be able to see each other.
+func configurePeerBootstrap(peer *etcdv1alpha1.EtcdPeer, cluster *etcdv1alpha1.EtcdCluster) {
+	peer.Spec.Bootstrap = &etcdv1alpha1.Bootstrap{
+		Static: &etcdv1alpha1.StaticBootstrap{
+			InitialCluster: initialClusterMembers(cluster),
+		},
+		InitialClusterState: etcdv1alpha1.InitialClusterStateNew,
+	}
+}
+
+func configureJoinExistingCluster(peer *etcdv1alpha1.EtcdPeer, cluster *etcdv1alpha1.EtcdCluster, members []etcdclient.Member) {
+	peer.Spec.Bootstrap = &etcdv1alpha1.Bootstrap{
+		Static: &etcdv1alpha1.StaticBootstrap{
+			InitialCluster: initialClusterMembersFromMemberList(cluster, members),
+		},
+		InitialClusterState: etcdv1alpha1.InitialClusterStateExisting,
 	}
 }
 
@@ -272,6 +492,27 @@ func initialClusterMembers(cluster *etcdv1alpha1.EtcdCluster) []etcdv1alpha1.Ini
 		}
 	}
 	return members
+}
+
+func initialClusterMembersFromMemberList(cluster *etcdv1alpha1.EtcdCluster, members []etcdclient.Member) []etcdv1alpha1.InitialClusterMember {
+	initialMembers := make([]etcdv1alpha1.InitialClusterMember, len(members))
+	for i, member := range members {
+		name, err := peerNameForMember(member)
+		if err != nil {
+			// We were not able to figure out what this peer's name should be. There is precious little we can do here
+			// so skip over this member.
+			continue
+		}
+		initialMembers[i] = etcdv1alpha1.InitialClusterMember{
+			Name: name,
+			// The member actually will always have at least one peer URL set (in the case where we're inspecting a
+			// member in the membership list that has never joined the cluster that is the only thing we'll see. But
+			// using that is actually painful as it's often strangely escaped. We bypass that issue by regenerating our
+			// expected url from the name.
+			Host: expectedURLForPeer(cluster, name),
+		}
+	}
+	return initialMembers
 }
 
 func nextAvailablePeerName(cluster *etcdv1alpha1.EtcdCluster, peers []etcdv1alpha1.EtcdPeer) string {

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -289,7 +289,7 @@ func (r *EtcdClusterReconciler) reconcile(
 			} else if *cluster.Spec.Replicas < int32(len(*members)) {
 				// There are too many members for the expected number of replicas. Remove the member with the highest
 				// ordinal
-				// TODO Implement scale-down
+				// TODO(#35) Implement scale-down
 			} else {
 				// Exactly the correct number of members. Make no change, all is well with the world.
 				log.V(2).Info("Expected number of replicas aligned with actual number.",

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -453,7 +453,10 @@ func (r *EtcdClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 
 	// List peers
 	peers := &etcdv1alpha1.EtcdPeerList{}
-	if err := r.List(ctx, peers, client.MatchingFields{clusterNameSpecField: cluster.Name}); err != nil {
+	if err := r.List(ctx,
+		peers,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingFields{clusterNameSpecField: cluster.Name}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to list peers: %w", err)
 	}
 

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -284,7 +284,7 @@ func (r *EtcdClusterReconciler) reconcile(
 					return ctrl.Result{}, nil, fmt.Errorf("failed to add new member %s: %w", peerName, err)
 				}
 				// Requeue, as we don't watch on the membership list. So we don't auto-detect the change we just made.
-				// TODO Implement custom watch on etcd membership API, and remove this requeue after member addition
+				// TODO(#76) Implement custom watch on etcd membership API, and remove this requeue after member addition
 				return ctrl.Result{RequeueAfter: time.Second * 10}, &reconcilerevent.MemberAddedEvent{Object: cluster, Member: member}, nil
 			} else if *cluster.Spec.Replicas < int32(len(*members)) {
 				// There are too many members for the expected number of replicas. Remove the member with the highest
@@ -302,7 +302,7 @@ func (r *EtcdClusterReconciler) reconcile(
 	// so that we can recheck the membership API. We currently do not implement any watch on the etcd API, and as it is
 	// not a Kubernetes API we will have to implement one custom.
 
-	// TODO Implement custom watch on etcd membership API, and remove this regular requeue
+	// TODO(#76) Implement custom watch on etcd membership API, and remove this regular requeue
 	return ctrl.Result{RequeueAfter: time.Second * 10}, nil, nil
 }
 

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -78,6 +78,16 @@ func bindAllAddress(port int) *url.URL {
 	}
 }
 
+func clusterStateValue(cs etcdv1alpha1.InitialClusterState) string {
+	if cs == etcdv1alpha1.InitialClusterStateNew {
+		return "new"
+	} else if cs == etcdv1alpha1.InitialClusterStateExisting {
+		return "existing"
+	} else {
+		return ""
+	}
+}
+
 func defineReplicaSet(peer etcdv1alpha1.EtcdPeer) appsv1.ReplicaSet {
 	var replicas int32 = 1
 
@@ -125,6 +135,10 @@ func defineReplicaSet(peer etcdv1alpha1.EtcdPeer) appsv1.ReplicaSet {
 									Value: peer.Name,
 								},
 								{
+									Name:  etcdenvvar.InitialClusterToken,
+									Value: peer.Spec.ClusterName,
+								},
+								{
 									Name:  etcdenvvar.InitialAdvertisePeerURLs,
 									Value: advertiseURL(peer, etcdPeerPort).String(),
 								},
@@ -142,7 +156,7 @@ func defineReplicaSet(peer etcdv1alpha1.EtcdPeer) appsv1.ReplicaSet {
 								},
 								{
 									Name:  etcdenvvar.InitialClusterState,
-									Value: "new",
+									Value: clusterStateValue(peer.Spec.Bootstrap.InitialClusterState),
 								},
 								{
 									Name:  etcdenvvar.DataDir,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"github.com/improbable-eng/etcd-cluster-operator/internal/etcd"
 	"path/filepath"
 	"testing"
 	"time"
@@ -20,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
+	"github.com/improbable-eng/etcd-cluster-operator/internal/etcd"
 )
 
 type controllerSuite struct {

--- a/internal/etcd/etcd.go
+++ b/internal/etcd/etcd.go
@@ -1,0 +1,22 @@
+package etcd
+
+import (
+	etcdclient "go.etcd.io/etcd/client"
+)
+
+// EtcdDailer is used to connect to etcd in the first place
+type EtcdAPI interface {
+	// Give an API that provides access to etcd membership API functions.
+	MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error)
+}
+
+type ClientEtcdAPI struct{}
+
+func (_ *ClientEtcdAPI) MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error) {
+	client, err := etcdclient.New(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return etcdclient.NewMembersAPI(client), nil
+}

--- a/internal/etcdenvvar/envvars.go
+++ b/internal/etcdenvvar/envvars.go
@@ -7,6 +7,7 @@ const (
 	InitialCluster           = "ETCD_INITIAL_CLUSTER"
 	ListenClientURLs         = "ETCD_LISTEN_CLIENT_URLS"
 	InitialClusterState      = "ETCD_INITIAL_CLUSTER_STATE"
+	InitialClusterToken      = "ETCD_INITIAL_CLUSTER_TOKEN"
 	Name                     = "ETCD_NAME"
 	DataDir                  = "ETCD_DATA_DIR"
 )

--- a/internal/reconcilerevent/cluster.go
+++ b/internal/reconcilerevent/cluster.go
@@ -46,5 +46,5 @@ func (s *MemberAddedEvent) Record(recorder record.EventRecorder) {
 	recorder.Event(s.Object,
 		"Normal",
 		"MemberAdded",
-		fmt.Sprintf("Added a new member with name %s", s.Member.Name))
+		fmt.Sprintf("Added a new member with name %q", s.Name))
 }

--- a/internal/reconcilerevent/cluster.go
+++ b/internal/reconcilerevent/cluster.go
@@ -21,7 +21,7 @@ func (s *ServiceCreatedEvent) Record(recorder record.EventRecorder) {
 	recorder.Event(s.Object,
 		"Normal",
 		"ServiceCreated",
-		fmt.Sprintf("Created service with name '%s'", s.ServiceName))
+		fmt.Sprintf("Created service with name %q", s.ServiceName))
 }
 
 type PeerCreatedEvent struct {
@@ -33,7 +33,7 @@ func (s *PeerCreatedEvent) Record(recorder record.EventRecorder) {
 	recorder.Event(s.Object,
 		"Normal",
 		"PeerCreated",
-		fmt.Sprintf("Created a new EtcdPeer with name '%s'", s.PeerName))
+		fmt.Sprintf("Created a new EtcdPeer with name %q", s.PeerName))
 }
 
 type MemberAddedEvent struct {

--- a/internal/reconcilerevent/cluster.go
+++ b/internal/reconcilerevent/cluster.go
@@ -39,6 +39,7 @@ func (s *PeerCreatedEvent) Record(recorder record.EventRecorder) {
 type MemberAddedEvent struct {
 	Object runtime.Object
 	Member *etcdclient.Member
+	Name   string
 }
 
 func (s *MemberAddedEvent) Record(recorder record.EventRecorder) {

--- a/internal/reconcilerevent/cluster.go
+++ b/internal/reconcilerevent/cluster.go
@@ -3,6 +3,7 @@ package reconcilerevent
 import (
 	"fmt"
 
+	etcdclient "go.etcd.io/etcd/client"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 )
@@ -33,4 +34,16 @@ func (s *PeerCreatedEvent) Record(recorder record.EventRecorder) {
 		"Normal",
 		"PeerCreated",
 		fmt.Sprintf("Created a new EtcdPeer with name '%s'", s.PeerName))
+}
+
+type MemberAddedEvent struct {
+	Object runtime.Object
+	Member *etcdclient.Member
+}
+
+func (s *MemberAddedEvent) Record(recorder record.EventRecorder) {
+	recorder.Event(s.Object,
+		"Normal",
+		"MemberAdded",
+		fmt.Sprintf("Added a new member with name %s", s.Member.Name))
 }

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -267,6 +267,7 @@ func TestE2E(t *testing.T) {
 	// with the remaining tests.
 	// Because the Etcd mutating and validating webhook service may not
 	// immediately be responding.
+	kubectl = kubectl.WithDefaultNamespace("default")
 	var out string
 	err := try.Eventually(func() (err error) {
 		out, err = kubectl.DryRun(sampleClusterPath)

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -377,7 +377,6 @@ func sampleClusterTests(t *testing.T, kubectl *kubectlContext, sampleClusterPath
 	require.NoError(t, err)
 
 	t.Run("EtcdClusterAvailability", func(t *testing.T) {
-		t.Parallel()
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 		defer cancel()
 
@@ -399,7 +398,6 @@ func sampleClusterTests(t *testing.T, kubectl *kubectlContext, sampleClusterPath
 	})
 
 	t.Run("EtcdClusterStatus", func(t *testing.T) {
-		t.Parallel()
 		kubectl := kubectl.WithT(t)
 		err := try.Eventually(func() error {
 			t.Log("")
@@ -408,8 +406,9 @@ func sampleClusterTests(t *testing.T, kubectl *kubectlContext, sampleClusterPath
 				return err
 			}
 			// Don't assert on exact members, just that we have three of them.
-			if len(strings.Split(members, " ")) != 3 {
-				return errors.New(fmt.Sprintf("Expected etcd member list to have three members. Had %d.", len(members)))
+			numMembers := len(strings.Split(members, " "))
+			if numMembers != 3 {
+				return errors.New(fmt.Sprintf("Expected etcd member list to have three members. Had %d.", numMembers))
 			}
 			return nil
 		}, time.Minute*2, time.Second*10)
@@ -426,7 +425,7 @@ func sampleClusterTests(t *testing.T, kubectl *kubectlContext, sampleClusterPath
 
 		err = try.Eventually(func() error {
 			t.Log("Listing etcd members")
-			members, err := etcd.NewMembersAPI(etcdClient).List(ctx)
+			members, err := etcd.NewMembersAPI(etcdClient).List(context.Background())
 			if err != nil {
 				return err
 			}

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -375,6 +375,9 @@ func runAllTests(t *testing.T, kubectl *kubectlContext) {
 				if member.ID == "" {
 					return errors.New("peer has no ID")
 				}
+				if member.Name == "" {
+					return errors.New("peer has no Name")
+				}
 			}
 			return nil
 		}, time.Minute*2, time.Second*10)

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -224,7 +224,7 @@ func setupLocalCluster(t *testing.T) (*cluster.Context, func()) {
 }
 
 func runAllTests(t *testing.T, kubectl *kubectlContext) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()
 
 	// Deploy a service to expose the cluster to the host machine.

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -224,7 +224,7 @@ func setupLocalCluster(t *testing.T) (*cluster.Context, func()) {
 }
 
 func runAllTests(t *testing.T, kubectl *kubectlContext) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer cancel()
 
 	// Deploy a service to expose the cluster to the host machine.
@@ -373,7 +373,7 @@ func runAllTests(t *testing.T, kubectl *kubectlContext) {
 					return errors.New("peer has no peer URLs")
 				}
 				if len(member.ID) == 0 {
-					return errors.New("Peer has no ID")
+					return errors.New("peer has no ID")
 				}
 			}
 			return nil

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -372,7 +372,7 @@ func runAllTests(t *testing.T, kubectl *kubectlContext) {
 				if len(member.PeerURLs) == 0 {
 					return errors.New("peer has no peer URLs")
 				}
-				if len(member.ID) == 0 {
+				if member.ID == "" {
 					return errors.New("peer has no ID")
 				}
 			}

--- a/internal/test/e2e/kubectl.go
+++ b/internal/test/e2e/kubectl.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -62,4 +63,10 @@ func (k *kubectlContext) Wait(args ...string) error {
 func (k *kubectlContext) DryRun(filename string) (string, error) {
 	out, err := k.do("apply", "--server-dry-run", "--output", "yaml", "--filename", filename)
 	return string(out), err
+}
+
+func (k *kubectlContext) Scale(resource string, scale uint) error {
+	out, err := k.do("scale", fmt.Sprintf("--replicas=%d", scale), resource)
+	k.t.Log(string(out))
+	return err
 }

--- a/internal/test/examples.go
+++ b/internal/test/examples.go
@@ -60,6 +60,7 @@ func ExampleEtcdPeer(namespace string) *v1alpha1.EtcdPeer {
 						},
 					},
 				},
+				InitialClusterState: v1alpha1.InitialClusterStateNew,
 			},
 			Storage: &v1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
 	"github.com/improbable-eng/etcd-cluster-operator/controllers"
+	"github.com/improbable-eng/etcd-cluster-operator/internal/etcd"
 	"github.com/improbable-eng/etcd-cluster-operator/webhooks"
 	// +kubebuilder:scaffold:imports
 )
@@ -60,6 +61,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("EtcdCluster"),
 		Recorder: mgr.GetEventRecorderFor("etcdcluster-reconciler"),
+		Etcd:     &etcd.ClientEtcdAPI{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EtcdCluster")
 		os.Exit(1)


### PR DESCRIPTION
Allows scalling up an etcd cluster. The scale subresource is implemented, and so kubectl can be used, e.g.

```
kubectl scale etcdcluster my-cluster --replicas 5
```

Fixes #34 
Also fixes #62 