### PR TITLE
Liveness probes for Etcd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test: bin/kubebuilder
 #  a) speed up the test run time slightly
 #  b) allow debug sessions to be attached to figure out what caused failures
 kind:
-	go test ./internal/test/e2e --kind --repo-root ${CURDIR} -v --cleanup=${CLEANUP} $(ARGS)
+	go test  -parallel 2 ./internal/test/e2e --kind --repo-root ${CURDIR} -v --cleanup=${CLEANUP} $(ARGS)
 
 # Build manager binary
 manager:

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -1,8 +1,10 @@
 package controllers
 
 const (
-	etcdClientPort    = 2379
-	etcdPeerPort      = 2380
+	etcdClientPort = 2379
+	etcdPeerPort   = 2380
+	// etcdMetricsPort is the port at which to obtain etcd metrics and health status
+	etcdMetricsPort   = 2381
 	etcdDataMountPath = "/var/lib/etcd"
 	appName           = "etcd"
 	appLabel          = "app.kubernetes.io/name"

--- a/internal/etcdenvvar/envvars.go
+++ b/internal/etcdenvvar/envvars.go
@@ -10,4 +10,5 @@ const (
 	InitialClusterToken      = "ETCD_INITIAL_CLUSTER_TOKEN"
 	Name                     = "ETCD_NAME"
 	DataDir                  = "ETCD_DATA_DIR"
+	ListenMetricsURLs        = "ETCD_LISTEN_METRICS_URLS"
 )


### PR DESCRIPTION
Part of #82 

Based on the liveness probe used by kubeadm for the kubernetes Etcd processes: https://github.com/kubernetes/kubernetes/pull/81385

The E2E test relies on details of a Kind cluster, so it is skipped in non-kind environments. 