### PR TITLE
Reduce the volume size in test clusters to 1Mi

### DIFF
--- a/config/samples/etcd_v1alpha1_etcdcluster.yaml
+++ b/config/samples/etcd_v1alpha1_etcdcluster.yaml
@@ -9,4 +9,4 @@ spec:
       storageClassName: standard
       resources:
         requests:
-          storage: 50Mi
+          storage: 1Mi

--- a/config/test/e2e/persistence/cluster.yaml
+++ b/config/test/e2e/persistence/cluster.yaml
@@ -9,4 +9,4 @@ spec:
       storageClassName: standard
       resources:
         requests:
-          storage: 50Mi
+          storage: 1Mi


### PR DESCRIPTION
This should help with local Kind clusters growing too big with repeated tests and with many parallel test etcdpeers.