### PR TITLE
Save the kind logs after the e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,3 +36,5 @@ jobs:
       - run:
          name: End to end tests
          command: make kind
+      - store_artifacts:
+          path: /tmp/kind-logs

--- a/internal/test/e2e/kubectl.go
+++ b/internal/test/e2e/kubectl.go
@@ -45,6 +45,9 @@ func (k *kubectlContext) do(args ...string) ([]byte, error) {
 	if err != nil {
 		err = fmt.Errorf("%s: %w", stderr.String(), err)
 	}
+	if stderr.Len() > 0 {
+		k.t.Logf("STDERR: %s", stderr.String())
+	}
 	return out, err
 }
 


### PR DESCRIPTION
To help diagnose test failures.

* Fixed a bug where the test was exiting before the kind cleanup had run
* Export the kind logs during kind cleanup
* Save those as circle-ci artifacts
* Log the stderr of successful kubectl commands
  * This reveals that the flakey persistence tests fail because the kubectl run doesn't always manage to attach to the container stdout

