### PR TITLE
Shorter tick time in tests

### DIFF
--- a/internal/test/try/try.go
+++ b/internal/test/try/try.go
@@ -9,12 +9,13 @@ import (
 // call to `fn' errors in the given time window.
 func Consistently(fn func() error, duration time.Duration, tick time.Duration) error {
 	timeout := time.After(duration)
-	ticker := time.Tick(tick)
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-timeout:
 			return nil
-		case <-ticker:
+		case <-ticker.C:
 			if err := fn(); err != nil {
 				return err
 			}
@@ -26,7 +27,8 @@ func Consistently(fn func() error, duration time.Duration, tick time.Duration) e
 // `duration'. It returns nil if `fn' stops erroring, otherwise the last error from `fn' is returned.
 func Eventually(fn func() error, duration time.Duration, tick time.Duration) error {
 	timeout := time.After(duration)
-	ticker := time.Tick(tick)
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
 	var lastErr error
 	for {
 		select {
@@ -35,7 +37,7 @@ func Eventually(fn func() error, duration time.Duration, tick time.Duration) err
 				return errors.New("function failed to return at least once")
 			}
 			return lastErr
-		case <-ticker:
+		case <-ticker.C:
 			lastErr = fn()
 			if lastErr == nil {
 				return nil

--- a/internal/test/try/try_test.go
+++ b/internal/test/try/try_test.go
@@ -90,7 +90,7 @@ func TestEventually(t *testing.T) {
 			fn: func(_ int) error {
 				return nil
 			},
-			tick:      time.Millisecond * 5,
+			tick:      time.Millisecond * 1,
 			duration:  time.Millisecond * 50,
 			expectErr: false,
 		},
@@ -99,7 +99,7 @@ func TestEventually(t *testing.T) {
 			fn: func(_ int) error {
 				return errors.New("foo")
 			},
-			tick:      time.Millisecond * 5,
+			tick:      time.Millisecond * 1,
 			duration:  time.Millisecond * 50,
 			expectErr: true,
 		},
@@ -111,7 +111,7 @@ func TestEventually(t *testing.T) {
 				}
 				return errors.New("foo")
 			},
-			tick:      time.Millisecond * 5,
+			tick:      time.Millisecond * 1,
 			duration:  time.Millisecond * 50,
 			expectErr: false,
 		},


### PR DESCRIPTION
Which should make it more likely that the success state is reached within 50ms