### PR TITLE
Scale down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
          name: End to end tests
          command: make kind
       - store_artifacts:
-          path: /tmp/kind-logs
+          path: /tmp/etcd-e2e
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,10 @@ test: bin/kubebuilder
 # Run end to end tests in a local Kind cluster. We do not clean up after running the tests to
 #  a) speed up the test run time slightly
 #  b) allow debug sessions to be attached to figure out what caused failures
+# We use -parallel 2 to try and avoid overloading the Circle CI server with too
+# many parallel EtcdClusters
 kind:
-	go test ./internal/test/e2e --kind --repo-root ${CURDIR} -v --cleanup=${CLEANUP} $(ARGS)
+	go test -parallel 2 ./internal/test/e2e --kind --repo-root ${CURDIR} -v --cleanup=${CLEANUP} $(ARGS)
 
 # Build manager binary
 manager:

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -38,13 +38,6 @@ func (o *EtcdCluster) ValidateUpdate(old runtime.Object) error {
 	}
 	oldO = oldO.DeepCopy()
 
-	if *oldO.Spec.Replicas > *o.Spec.Replicas {
-		return fmt.Errorf(
-			"Unsupported changes: spec.replicas: current: %d, new: %d: scale-in is not supported",
-			*oldO.Spec.Replicas, *o.Spec.Replicas,
-		)
-	}
-
 	// Overwrite the fields which are allowed to change
 	oldO.Spec.Replicas = o.Spec.Replicas
 

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -62,17 +62,16 @@ func TestEtcdCluster_ValidateUpdate(t *testing.T) {
 		err      string
 	}{
 		{
-			name: "ScaleOut",
+			name: "ScaleUp",
 			modifier: func(o *v1alpha1.EtcdCluster) {
 				*o.Spec.Replicas += 1
 			},
 		},
 		{
-			name: "UnsupportedChange/ScaleIn",
+			name: "ScaleDown",
 			modifier: func(o *v1alpha1.EtcdCluster) {
 				*o.Spec.Replicas -= 1
 			},
-			err: "scale-in is not supported",
 		},
 		{
 			name: "UnsupportedChange/StorageClassName",

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -102,6 +102,7 @@ rules:
   - etcdpeers
   verbs:
   - create
+  - delete
   - get
   - list
   - watch

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -471,7 +471,7 @@ func peerNameForMember(member etcdclient.Member) (string, error) {
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create
-// +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *EtcdClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -146,7 +148,6 @@ func (r *EtcdClusterReconciler) createPeerForMember(ctx context.Context, cluster
 		return nil, err
 	}
 	return &reconcilerevent.PeerCreatedEvent{Object: cluster, PeerName: peer.Name}, nil
-
 }
 
 func (r *EtcdClusterReconciler) addNewMember(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster, peers *etcdv1alpha1.EtcdPeerList) (*reconcilerevent.MemberAddedEvent, error) {
@@ -160,6 +161,30 @@ func (r *EtcdClusterReconciler) addNewMember(ctx context.Context, cluster *etcdv
 		return nil, err
 	}
 	return &reconcilerevent.MemberAddedEvent{Object: cluster, Member: member, Name: peerName}, nil
+}
+
+// MembersByName provides a sort.Sort interface for etcdClient.Member.Name
+type MembersByName []etcdclient.Member
+
+func (a MembersByName) Len() int           { return len(a) }
+func (a MembersByName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a MembersByName) Less(i, j int) bool { return a[i].Name < a[j].Name }
+
+// removeMember selects the Etcd node which has a name with the largest ordinal,
+// then performs a runtime reconfiguration to remove that member from the Etcd
+// cluster, and generates an Event to record that action.
+// TODO(wallrj) Consider removing a non-leader member to avoid disruptive
+// leader elections while scaling down.
+// See https://github.com/improbable-eng/etcd-cluster-operator/issues/97
+func (r *EtcdClusterReconciler) removeMember(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster, members []etcdclient.Member) (*reconcilerevent.MemberRemovedEvent, error) {
+	sortedMembers := append(members[:0:0], members...)
+	sort.Sort(sort.Reverse(MembersByName(sortedMembers)))
+	member := sortedMembers[0]
+	err := r.removeEtcdMember(ctx, cluster, member.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &reconcilerevent.MemberRemovedEvent{Object: cluster, Member: &member, Name: member.Name}, nil
 }
 
 // updateStatus updates the EtcdCluster resource's status to be the current value of the cluster.
@@ -336,9 +361,6 @@ func (r *EtcdClusterReconciler) reconcile(
 			}
 		}
 
-		// Remove EtcdPeer resources which do not have members.
-		// TODO(#35) Implement scale-down
-
 		// If we've reached this point we're sure that the EtcdPeer resources in the cluster match the contents of the
 		// membership API. The next step is checking to see if we want to mutate the membership API of etcd to scale up
 		// or down. However we don't want to do this unless the cluster has stabilised from a previous member addition.
@@ -360,14 +382,45 @@ func (r *EtcdClusterReconciler) reconcile(
 					"peer-url", memberAddedEvent.Member.PeerURLs[0])
 				return result, memberAddedEvent, nil
 			} else if hasTooManyMembers(cluster, *members) {
-				// There are too many members for the expected number of replicas. Remove the member with the highest
-				// ordinal
-				// TODO(#35) Implement scale-down
+				// There are too many members for the expected number of replicas.
+				// Remove the member with the highest ordinal.
+				memberRemovedEvent, err := r.removeMember(ctx, cluster, *members)
+				if err != nil {
+					return result, nil, fmt.Errorf("failed to remove member: %w", err)
+				}
+
+				log.V(1).Info("Too many members for expected replica count, removing member.",
+					"expected-replicas", *cluster.Spec.Replicas,
+					"actual-members", len(*members),
+					"peer-name", memberRemovedEvent.Name,
+					"peer-url", memberRemovedEvent.Member.PeerURLs[0])
+
+				return result, memberRemovedEvent, nil
 			} else {
 				// Exactly the correct number of members. Make no change, all is well with the world.
 				log.V(2).Info("Expected number of replicas aligned with actual number.",
 					"expected-replicas", *cluster.Spec.Replicas,
 					"actual-members", len(*members))
+			}
+
+			// Remove EtcdPeer resources which do not have members.
+			memberNames := sets.NewString()
+			for _, member := range *members {
+				memberNames.Insert(member.Name)
+			}
+
+			for _, peer := range peers.Items {
+				if !memberNames.Has(peer.Name) {
+					err := r.Delete(ctx, &peer)
+					if err != nil {
+						return result, nil, fmt.Errorf("failed to remove peer: %w", err)
+					}
+					peerRemovedEvent := &reconcilerevent.PeerRemovedEvent{
+						Object:   &peer,
+						PeerName: peer.Name,
+					}
+					return result, peerRemovedEvent, nil
+				}
 			}
 		}
 	}
@@ -495,6 +548,21 @@ func (r *EtcdClusterReconciler) addEtcdMember(ctx context.Context, cluster *etcd
 	}
 
 	return members, nil
+}
+
+// removeEtcdMember performs a runtime reconfiguration of the Etcd cluster to
+// remove a member from the cluster.
+func (r *EtcdClusterReconciler) removeEtcdMember(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster, memberID string) error {
+	c, err := r.Etcd.MembershipAPI(etcdClientConfig(cluster))
+	if err != nil {
+		return fmt.Errorf("unable to connect to etcd: %w", err)
+	}
+	err = c.Remove(ctx, memberID)
+	if err != nil {
+		return fmt.Errorf("unable to remove member from etcd cluster: %w", err)
+	}
+
+	return nil
 }
 
 func (r *EtcdClusterReconciler) getEtcdMembers(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster) ([]etcdclient.Member, error) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -31,7 +31,7 @@ type controllerSuite struct {
 }
 
 func setupSuite(t *testing.T) (suite *controllerSuite, teardownFunc func()) {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Minute*5)
 
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	logtest "github.com/go-logr/logr/testing"
 	"github.com/stretchr/testify/require"
 	etcdclient "go.etcd.io/etcd/client"
 	v1 "k8s.io/api/core/v1"
@@ -20,6 +19,7 @@ import (
 
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
 	"github.com/improbable-eng/etcd-cluster-operator/internal/etcd"
+	"github.com/improbable-eng/etcd-cluster-operator/internal/test"
 )
 
 type controllerSuite struct {
@@ -79,8 +79,7 @@ func (s *controllerSuite) MembershipAPI(config etcdclient.Config) (etcdclient.Me
 
 func (s *controllerSuite) setupTest(t *testing.T) (teardownFunc func(), namespaceName string) {
 	stopCh := make(chan struct{})
-
-	logger := logtest.TestLogger{
+	logger := test.TestLogger{
 		T: t,
 	}
 	// This allows us to see controller-runtime logs in the test results.
@@ -103,16 +102,14 @@ func (s *controllerSuite) setupTest(t *testing.T) (teardownFunc func(), namespac
 
 	peerController := EtcdPeerReconciler{
 		Client: mgr.GetClient(),
-		Log:    logger,
+		Log:    logger.WithName("EtcdPeer"),
 	}
 	err = peerController.SetupWithManager(mgr)
 	require.NoError(t, err, "failed to set up EtcdPeer controller")
 
 	clusterController := EtcdClusterReconciler{
-		Client: mgr.GetClient(),
-		Log: logtest.TestLogger{
-			T: t,
-		},
+		Client:   mgr.GetClient(),
+		Log:      logger.WithName("EtcdCluster"),
 		Recorder: mgr.GetEventRecorderFor("etcdcluster-reconciler"),
 		Etcd:     s,
 	}

--- a/internal/reconcilerevent/cluster.go
+++ b/internal/reconcilerevent/cluster.go
@@ -36,6 +36,18 @@ func (s *PeerCreatedEvent) Record(recorder record.EventRecorder) {
 		fmt.Sprintf("Created a new EtcdPeer with name %q", s.PeerName))
 }
 
+type PeerRemovedEvent struct {
+	Object   runtime.Object
+	PeerName string
+}
+
+func (s *PeerRemovedEvent) Record(recorder record.EventRecorder) {
+	recorder.Event(s.Object,
+		"Normal",
+		"PeerRemoved",
+		fmt.Sprintf("Removed EtcdPeer with name %q", s.PeerName))
+}
+
 type MemberAddedEvent struct {
 	Object runtime.Object
 	Member *etcdclient.Member
@@ -47,4 +59,17 @@ func (s *MemberAddedEvent) Record(recorder record.EventRecorder) {
 		"Normal",
 		"MemberAdded",
 		fmt.Sprintf("Added a new member with name %q", s.Name))
+}
+
+type MemberRemovedEvent struct {
+	Object runtime.Object
+	Member *etcdclient.Member
+	Name   string
+}
+
+func (s *MemberRemovedEvent) Record(recorder record.EventRecorder) {
+	recorder.Event(s.Object,
+		"Normal",
+		"MemberRemoved",
+		fmt.Sprintf("Removed a member with name %q", s.Name))
 }

--- a/internal/test/e2e/testdata/zero-resource-quota.yaml
+++ b/internal/test/e2e/testdata/zero-resource-quota.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: evict-all-pods
+spec:
+  hard:
+    pods: "0"

--- a/internal/test/log.go
+++ b/internal/test/log.go
@@ -1,0 +1,47 @@
+// Copied from "github.com/go-logr/logr/testing"
+// With added implementation of log.Info, log.V, log.WithName and log.WithValues
+
+package test
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// TestLogger is a logr.Logger that prints through a testing.T object.
+type TestLogger struct {
+	T      *testing.T
+	v      int
+	name   string
+	values []interface{}
+}
+
+var _ logr.Logger = TestLogger{}
+
+func (log TestLogger) Info(msg string, args ...interface{}) {
+	log.T.Logf("log.V(%d).WithName(%q).Info: %s -- %v", log.v, log.name, msg, append(log.values, args...))
+}
+
+func (_ TestLogger) Enabled() bool {
+	return false
+}
+
+func (log TestLogger) Error(err error, msg string, args ...interface{}) {
+	log.T.Logf("log.V(%d).WithName(%q).Error: %s: %v -- %v", log.v, log.name, msg, err, append(log.values, args...))
+}
+
+func (log TestLogger) V(v int) logr.InfoLogger {
+	log.v = v
+	return log
+}
+
+func (log TestLogger) WithName(name string) logr.Logger {
+	log.name = name
+	return log
+}
+
+func (log TestLogger) WithValues(values ...interface{}) logr.Logger {
+	log.values = values
+	return log
+}


### PR DESCRIPTION
Part of #35 

* Scale down by removing the member with the largest ordinal name 
* Updated E2E tests to cleanup pods after each test, otherwise E2E tests were failing on Circle CI, because I  think the VM was running so slowly. Grab logs of namespace pods before they are deleted, for diagnostics.
* Updated unit / integration tests to log all the operator logs, rather than only errors. This allowed me to see exactly what the operator was doing during scale-down integration tests
* Updated the Fake Etcd client to support removal of members during integration tests