### PR TITLE
Debug docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# When set, the container will be built with debug tools installed.
+ARG image=alpine:3.10.3
+ARG user=root
+
 # Build the manager binary
 FROM golang:1.13.1 as builder
 
@@ -19,11 +23,13 @@ COPY webhooks/ webhooks/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM $image 
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER $user:$user
+
+ARG debug=false
+
+RUN if [ "$debug" = "true" ] ; then apk update && apk add ca-certificates bash curl drill jq ; fi
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,13 @@ gomod:
 verify-gomod:
 	./hack/verify.sh make -s gomod
 
-# Build the docker image
+# Build the docker image. This should be used for release versions, and builds the image on top of distroless.
 docker-build: test
-	docker build . -t ${IMG}
+	docker build . -t ${IMG} --build-arg image=gcr.io/distroless/static:nonroot --build-arg user=nonroot
+
+# Build the docker image with debug tools installed.
+docker-build-debug: test
+	docker build . -t ${IMG} --build-arg debug=true
 
 # Push the docker image
 docker-push:

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -153,7 +153,7 @@ func buildOperator(t *testing.T, ctx context.Context) (imageTar string, err erro
 	operatorImage := "etcd-cluster-operator:test"
 
 	// Build the operator.
-	out, err := exec.CommandContext(ctx, "docker", "build", "-t", operatorImage, *fRepoRoot).CombinedOutput()
+	out, err := exec.CommandContext(ctx, "docker", "build", "-t", operatorImage, *fRepoRoot, "--build-arg=debug=true").CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%w Output: %s", err, out)
 	}


### PR DESCRIPTION
this PR changes the default behaviour of the dockerfile to build on alpine. 
this behaviour is overridden in the makefile, so there will be no changes to release images.
e2e tests now build debug containers, and a new makefile target exists to allow building of debug images.