### PR TITLE
Allow scaled-down clusters to be scaled back up

### DIFF
--- a/api/v1alpha1/etcdpeer_types.go
+++ b/api/v1alpha1/etcdpeer_types.go
@@ -66,6 +66,10 @@ type EtcdPeerSpec struct {
 	// Storage is the configuration of the disks and mount points of the Etcd
 	// pod.
 	Storage *EtcdPeerStorage `json:"storage,omitempty"`
+
+	// Decommissioned is set to true if this EtcdPeer has been removed from an etcd cluster
+	// and its data can be safely deleted.
+	Decommissioned bool `json:"decommissioned"`
 }
 
 // EtcdPeerStorage defines the desired storage for an EtcdPeer

--- a/api/v1alpha1/etcdpeer_types.go
+++ b/api/v1alpha1/etcdpeer_types.go
@@ -69,6 +69,7 @@ type EtcdPeerSpec struct {
 
 	// Decommissioned is set to true if this EtcdPeer has been removed from an etcd cluster
 	// and its data can be safely deleted.
+	// +optional
 	Decommissioned bool `json:"decommissioned"`
 }
 

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -77,7 +77,7 @@ func (o *EtcdPeer) ValidateUpdate(old runtime.Object) error {
 	oldO = oldO.DeepCopy()
 
 	// Overwrite any the fields which are allowed to change
-	// oldO.Spec.Foo = o.Spec.Foo
+	oldO.Spec.Decommissioned = o.Spec.Decommissioned
 
 	if diff := cmp.Diff(oldO.Spec, o.Spec); diff != "" {
 		return fmt.Errorf("Unsupported changes: (- current, + new) %s", diff)

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -158,6 +158,12 @@ func TestEtcdPeer_ValidateUpdate(t *testing.T) {
 		err      string
 	}{
 		{
+			name: "SupportedChange/Decommissioned",
+			modifier: func(o *v1alpha1.EtcdPeer) {
+				o.Spec.Decommissioned = !o.Spec.Decommissioned
+			},
+		},
+		{
 			name: "UnsupportedChange/StorageClassName",
 			modifier: func(o *v1alpha1.EtcdPeer) {
 				*o.Spec.Storage.VolumeClaimTemplate.StorageClassName += "-changed"

--- a/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
@@ -90,6 +90,10 @@ spec:
                 label on the Pod running etcd.
               maxLength: 64
               type: string
+            decommissioned:
+              description: Decommissioned is set to true if this EtcdPeer has been
+                removed from an etcd cluster and its data can be safely deleted.
+              type: boolean
             storage:
               description: Storage is the configuration of the disks and mount points
                 of the Etcd pod.
@@ -216,6 +220,7 @@ spec:
               type: object
           required:
           - clusterName
+          - decommissioned
           type: object
         status:
           description: EtcdPeerStatus defines the observed state of EtcdPeer

--- a/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
@@ -220,7 +220,6 @@ spec:
               type: object
           required:
           - clusterName
-          - decommissioned
           type: object
         status:
           description: EtcdPeerStatus defines the observed state of EtcdPeer

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,7 @@ rules:
   - persistentvolumeclaims
   verbs:
   - create
+  - delete
   - get
   - list
   - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -101,6 +101,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - etcd.improbable.io

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -37,7 +37,12 @@ const (
 	pvcCleanupFinalizer = "etcdpeer.etcd.improbable.io/pvc-cleanup"
 )
 
-// +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers,verbs=get;list;watch
+// TODO(wallrj) Ideally this controller wouldn't need permission to modify the
+// EtcdPeer resource, but it is required so that it can add and remove
+// finalizers.
+// See https://github.com/kubernetes/kubernetes/issues/59591
+
+// +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=list;get;create;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=list;get;create;watch

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -252,6 +252,16 @@ func hasPvcDeletionFinalizer(peer etcdv1alpha1.EtcdPeer) bool {
 	return sets.NewString(peer.ObjectMeta.Finalizers...).Has(pvcCleanupFinalizer)
 }
 
+func removeString(haystack []string, needle string) (result []string) {
+	for _, s := range haystack {
+		if s == needle {
+			continue
+		}
+		result = append(result, s)
+	}
+	return result
+}
+
 func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -278,7 +288,7 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	if peer.ObjectMeta.DeletionTimestamp.IsZero() {
 		if !hasPvcDeletionFinalizer(peer) {
-			r.Log.V(2).Info("Adding PVC cleanup finalizer")
+			log.V(2).Info("Adding PVC cleanup finalizer")
 			updated := peer.DeepCopy()
 			updated.ObjectMeta.Finalizers = append(
 				updated.ObjectMeta.Finalizers,
@@ -288,8 +298,37 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to add PVC cleanup finalizer: %w", err)
 			}
+			log.V(2).Info("Added PVC cleanup finalizer")
 			return ctrl.Result{}, nil
 		}
+	} else {
+		if hasPvcDeletionFinalizer(peer) {
+			if peer.Spec.Decommissioned {
+				log.V(2).Info("Deleting PVC for decommissioned peer prior to deletion")
+				expectedPvc := pvcForPeer(&peer)
+				err := r.Delete(ctx, expectedPvc)
+				if err == nil {
+					log.V(2).Info("Deleted PVC")
+					return ctrl.Result{}, nil
+				}
+				if client.IgnoreNotFound(err) != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to delete PVC: %w", err)
+				}
+			} else {
+				log.V(2).Info("Not deleting PVC because this peer is not decommissioned")
+			}
+			log.V(2).Info("Removing PVC cleanup finalizer")
+			updated := peer.DeepCopy()
+			updated.ObjectMeta.Finalizers = removeString(
+				updated.ObjectMeta.Finalizers,
+				pvcCleanupFinalizer,
+			)
+			if err := r.Patch(ctx, updated, client.MergeFrom(&peer)); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to remove PVC cleanup finalizer: %w", err)
+			}
+			log.V(2).Info("Removed PVC cleanup finalizer")
+		}
+		return ctrl.Result{}, nil
 	}
 
 	created, err := r.maybeCreatePvc(ctx, &peer)

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -348,7 +348,11 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 				log.V(2).Info("Not deleting PVC because this peer is not decommissioned")
 			}
 
-			// If we reach this stage, the PVC has been deleted
+			// If we reach this stage, the PVC has been deleted or didn't need
+			// deleting.
+			// Remove the finalizer so that the EtcdPeer can be garbage
+			// collected along with its replicaset, pod...and with that the PVC
+			// will finally be deleted by the garbage collector.
 			log.V(2).Info("Removing PVC cleanup finalizer")
 			updated := peer.DeepCopy()
 			updated.ObjectMeta.Finalizers = removeString(

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -45,7 +45,7 @@ const (
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=list;get;create;watch
-// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=list;get;create;watch
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=list;get;create;watch;delete
 
 func initialMemberURL(member etcdv1alpha1.InitialClusterMember) *url.URL {
 	return &url.URL{

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -304,15 +304,14 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	} else {
 		if hasPvcDeletionFinalizer(peer) {
 			if peer.Spec.Decommissioned {
-				log.V(2).Info("Deleting PVC for decommissioned peer prior to deletion")
 				expectedPvc := pvcForPeer(&peer)
 				err := r.Delete(ctx, expectedPvc)
 				if err == nil {
-					log.V(2).Info("Deleted PVC")
+					log.V(2).Info("Deleted PVC for decommissioned peer")
 					return ctrl.Result{}, nil
 				}
 				if client.IgnoreNotFound(err) != nil {
-					return ctrl.Result{}, fmt.Errorf("failed to delete PVC: %w", err)
+					return ctrl.Result{}, fmt.Errorf("failed to delete PVC for decommissioned peer: %w", err)
 				}
 			} else {
 				log.V(2).Info("Not deleting PVC because this peer is not decommissioned")

--- a/controllers/etcdpeer_controller_test.go
+++ b/controllers/etcdpeer_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -153,5 +154,85 @@ func (s *controllerSuite) testPeerController(t *testing.T) {
 		peer.Default()
 
 		require.Equal(t, *peer.Spec.Storage.VolumeClaimTemplate, actualPvc.Spec, "Unexpected PVC spec")
+	})
+	t.Run("LeavesPersistentVolumeClaimIfCommissioned", func(t *testing.T) {
+		teardown, namespace := s.setupTest(t)
+		defer teardown()
+
+		t.Log("Given an EtcdPeer with a PVC")
+		peer := exampleEtcdPeer(namespace)
+		peerKey, err := client.ObjectKeyFromObject(peer)
+		require.NoError(t, err)
+		err = s.k8sClient.Create(s.ctx, peer)
+		require.NoError(t, err, "failed to create EtcdPeer resource")
+		actualPvc := corev1.PersistentVolumeClaim{}
+		err = try.Eventually(
+			func() error { return s.k8sClient.Get(s.ctx, peerKey, &actualPvc) },
+			time.Second*5, time.Millisecond*500,
+		)
+		require.NoError(t, err, "PVC was not created")
+
+		t.Log("If the EtcdPeer is deleted")
+		err = s.k8sClient.Delete(s.ctx, peer)
+		require.NoError(t, err, "failed to delete EtcdPeer resource")
+		err = try.Eventually(
+			func() error {
+				var actualPeer etcdv1alpha1.EtcdPeer
+				err := s.k8sClient.Get(s.ctx, peerKey, &actualPeer)
+				if err == nil {
+					return fmt.Errorf("the EtcdPeer has not been deleted")
+				}
+				return client.IgnoreNotFound(err)
+			},
+			time.Second*5, time.Millisecond*500,
+		)
+		require.NoErrorf(t, err, "EtcdPeer was not deleted: %v", peerKey)
+
+		t.Log("The PVC is not deleted")
+		err = s.k8sClient.Get(s.ctx, peerKey, &actualPvc)
+		require.NoError(t, err, "PVC was deleted")
+	})
+	t.Run("DeletesPersistentVolumeClaimIfDecommissioned", func(t *testing.T) {
+		teardown, namespace := s.setupTest(t)
+		defer teardown()
+
+		t.Log("Given an EtcdPeer with a PVC")
+		peer := exampleEtcdPeer(namespace)
+		peerKey, err := client.ObjectKeyFromObject(peer)
+		require.NoError(t, err)
+		err = s.k8sClient.Create(s.ctx, peer)
+		require.NoError(t, err, "failed to create EtcdPeer resource")
+		actualPvc := corev1.PersistentVolumeClaim{}
+		err = try.Eventually(
+			func() error { return s.k8sClient.Get(s.ctx, peerKey, &actualPvc) },
+			time.Second*5, time.Millisecond*500,
+		)
+		require.NoError(t, err, "PVC was not created")
+
+		t.Log("If the EtcdPeer is decommissioned and deleted")
+		patch := client.MergeFrom(peer.DeepCopy())
+		peer.Spec.Decommissioned = true
+		err = s.k8sClient.Patch(s.ctx, peer, patch)
+		require.NoError(t, err, "failed to patch EtcdPeer resource")
+
+		err = s.k8sClient.Delete(s.ctx, peer)
+		require.NoError(t, err, "failed to delete EtcdPeer resource")
+		err = try.Eventually(
+			func() error {
+				var actualPeer etcdv1alpha1.EtcdPeer
+				err := s.k8sClient.Get(s.ctx, peerKey, &actualPeer)
+				if err == nil {
+					return fmt.Errorf("the EtcdPeer has not been deleted")
+				}
+				return client.IgnoreNotFound(err)
+			},
+			time.Second*5, time.Millisecond*500,
+		)
+		require.NoErrorf(t, err, "EtcdPeer was not deleted: %v", peerKey)
+
+		t.Log("The PVC is deleted")
+		err = s.k8sClient.Get(s.ctx, peerKey, &actualPvc)
+		require.NoError(t, client.IgnoreNotFound(err), "unexpected error")
+		assert.Error(t, err, "expected a NotFound error for deleted PVC")
 	})
 }

--- a/controllers/etcdpeer_controller_test.go
+++ b/controllers/etcdpeer_controller_test.go
@@ -210,7 +210,7 @@ func (s *controllerSuite) testPeerController(t *testing.T) {
 		require.NoError(t, err, "PVC was not created")
 
 		t.Log("If the EtcdPeer is decommissioned and deleted")
-		patch := client.MergeFrom(peer.DeepCopy())
+		patch := client.MergeFrom(peer)
 		peer.Spec.Decommissioned = true
 		err = s.k8sClient.Patch(s.ctx, peer, patch)
 		require.NoError(t, err, "failed to patch EtcdPeer resource")

--- a/controllers/etcdpeer_controller_test.go
+++ b/controllers/etcdpeer_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -230,17 +231,8 @@ func (s *controllerSuite) testPeerController(t *testing.T) {
 		require.NoErrorf(t, err, "EtcdPeer was not deleted: %v", peerKey)
 
 		t.Log("The PVC is also deleted")
-		err = try.Eventually(
-			func() error {
-				err = s.k8sClient.Get(s.ctx, peerKey, &actualPvc)
-				require.NoError(t, client.IgnoreNotFound(err))
-				if err == nil {
-					return fmt.Errorf("expected a NotFound error for deleted PVC: %s", peerKey)
-				}
-				return nil
-			},
-			time.Second*5, time.Millisecond*500,
-		)
-		require.NoErrorf(t, err, "PVC was not deleted: %v", peerKey)
+		err = s.k8sClient.Get(s.ctx, peerKey, &actualPvc)
+		require.NoError(t, client.IgnoreNotFound(err))
+		assert.Errorf(t, err, "expected a NotFound error for deleted PVC: %s", peerKey)
 	})
 }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -182,7 +182,7 @@ $ kubectl apply -f config/samples/etcd_v1alpha1_etcdcluster.yaml
 
 You could also use `kubectl scale` to do this, e.g.,
 
-```bash 
+```bash
 $ kubectl scale etcdcluster my-cluster --replicas 1
 ```
 
@@ -200,17 +200,13 @@ during which the cluster will *not be able to process write requests*.
 
 The etcd process running in Pod "my-cluster-2" will exit with exit-code 0, and the Pod will be marked as "Complete".
 
-Next, the operator will remove the `EtcdPeer` resource for the removed `etcd` member. This will trigger the deletion of
-the `Replicaset` and the `Pod`  for "my-cluster-2", but **not** the `PersistentVolumeClaim` or the `PersistentVolume`,
-for the reasons described in "### Delete a Cluster" (above).
+Next, the operator will remove the `EtcdPeer` resource for the removed `etcd` member.
+This will trigger the deletion of the `Replicaset` and the `Pod` and the `PersistentVolumeClaim` for "my-cluster-2".
+The `PersistentVolume` (and the data) for the removed `etcd` node *may* be deleted
+depending on the "Reclaim Policy" of the `StorageClass` associated with the `PersistentVolume`.
 
 When all these operations are complete the `EtcdCluster.Status` will be updated to show the new number of replicas
 and the new list of `etcd` members.
 
 Additionally, the `etcd-cluster-operator` will generate an `Event` for each operation it successfully performs,
 which allows you to track the progress of the scale down operations.
-
-If you want to scale up an `EtcdCluster` which has previously been scaled down,
-you must first remove the `PersistentVolumeClaim` associated with any `EtcdPeer` that was removed during the scale down
-operations. Otherwise new `EtcdPeer` and `Pods` will be started with `/var/lib/etcd` data corresponding to an old etcd
-member ID, and the node will fail to join the cluster.

--- a/internal/reconcilerevent/cluster.go
+++ b/internal/reconcilerevent/cluster.go
@@ -48,6 +48,18 @@ func (s *PeerRemovedEvent) Record(recorder record.EventRecorder) {
 		fmt.Sprintf("Removed EtcdPeer with name %q", s.PeerName))
 }
 
+type PeerDecommissionedEvent struct {
+	Object   runtime.Object
+	PeerName string
+}
+
+func (s *PeerDecommissionedEvent) Record(recorder record.EventRecorder) {
+	recorder.Event(s.Object,
+		"Normal",
+		"PeerDecommissioned",
+		fmt.Sprintf("Decommissioned EtcdPeer with name %q", s.PeerName))
+}
+
 type MemberAddedEvent struct {
 	Object runtime.Object
 	Member *etcdclient.Member

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -622,7 +622,7 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 	configPath := filepath.Join(*fRepoRoot, "config", "samples", "etcd_v1alpha1_etcdcluster.yaml")
 	err := kubectl.Apply("--filename", configPath)
 	require.NoError(t, err)
-
+	const expectedReplicasOriginal = 3
 	t.Log("Where all the nodes are up")
 	err = try.Eventually(
 		func() error {
@@ -634,8 +634,8 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 			if err != nil {
 				return err
 			}
-			if statusReplicas != 3 {
-				return fmt.Errorf("unexpected status.replicas. Wanted: 3, Got: %d", statusReplicas)
+			if statusReplicas != expectedReplicasOriginal {
+				return fmt.Errorf("unexpected status.replicas. Wanted: %d, Got: %d", expectedReplicasOriginal, statusReplicas)
 			}
 			return nil
 		},
@@ -657,8 +657,9 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 	require.NoError(t, err, out)
 
 	t.Log("If the cluster is scaled down")
-	const expectedReplicas = 1
-	err = kubectl.Scale("etcdcluster/my-cluster", expectedReplicas)
+	const expectedReplicasNew = 1
+	require.True(t, expectedReplicasNew < expectedReplicasOriginal, "Must use a lower replicas count")
+	err = kubectl.Scale("etcdcluster/my-cluster", expectedReplicasNew)
 	require.NoError(t, err)
 
 	t.Log("The etcdcluster.status is updated when the cluster has been resized.")
@@ -668,8 +669,8 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 			require.NoError(t, err, out)
 			statusReplicas, err := strconv.Atoi(out)
 			require.NoError(t, err, out)
-			if expectedReplicas != statusReplicas {
-				return fmt.Errorf("unexpected status.replicas. Wanted: %d, Got: %d", expectedReplicas, statusReplicas)
+			if expectedReplicasNew != statusReplicas {
+				return fmt.Errorf("unexpected status.replicas. Wanted: %d, Got: %d", expectedReplicasNew, statusReplicas)
 			}
 			return err
 		},
@@ -688,4 +689,26 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 	)
 	require.NoError(t, err, out)
 	assert.Equal(t, expectedValue+"\n", out)
+
+	t.Log("The cluster can then be scaled back up")
+	err = kubectl.Scale("etcdcluster/my-cluster", expectedReplicasOriginal)
+	require.NoError(t, err)
+	err = try.Eventually(
+		func() error {
+			out, err := kubectl.Get("etcdcluster", "my-cluster", "-o=jsonpath={.status.replicas}")
+			if err != nil {
+				return err
+			}
+			statusReplicas, err := strconv.Atoi(out)
+			if err != nil {
+				return err
+			}
+			if statusReplicas != expectedReplicasOriginal {
+				return fmt.Errorf("unexpected status.replicas. Wanted: %d, Got: %d", expectedReplicasOriginal, statusReplicas)
+			}
+			return nil
+		},
+		time.Minute*2, time.Second*10,
+	)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
* Add a Decommissioned flag to EtcdPeer
* Add a finalizer and delete the PVC for a decommissioned EtcdPeer
* Decommission EtcdPeers when scaling down

Fixes: #101