### PR TITLE
Allow scaled-down clusters to be scaled back up (v2)

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,7 @@ rules:
   - persistentvolumeclaims
   verbs:
   - create
+  - delete
   - get
   - list
   - watch
@@ -101,6 +102,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - etcd.improbable.io

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
 	"github.com/improbable-eng/etcd-cluster-operator/internal/etcd"
@@ -417,10 +418,7 @@ func (r *EtcdClusterReconciler) reconcile(
 					}
 					if !hasPvcDeletionFinalizer(peer) {
 						updated := peer.DeepCopy()
-						updated.ObjectMeta.Finalizers = append(
-							updated.ObjectMeta.Finalizers,
-							pvcCleanupFinalizer,
-						)
+						controllerutil.AddFinalizer(updated, pvcCleanupFinalizer)
 						err := r.Patch(ctx, updated, client.MergeFrom(&peer))
 						if err != nil {
 							return result, nil, fmt.Errorf("failed to add PVC cleanup finalizer: %w", err)

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -488,7 +488,7 @@ func peerNameForMember(member etcdclient.Member) (string, error) {
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create
-// +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers,verbs=get;list;watch;create;delete;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *EtcdClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -364,9 +364,8 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 					if err == nil {
 						log.V(2).Info("Deleted PVC for peer")
 						return ctrl.Result{}, nil
-					} else {
-						return ctrl.Result{}, fmt.Errorf("failed to delete PVC for peer: %w", err)
 					}
+					return ctrl.Result{}, fmt.Errorf("failed to delete PVC for peer: %w", err)
 				} else {
 					log.V(2).Info("PVC for peer has already been marked for deletion")
 				}

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -338,6 +338,7 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
+	// Check if the peer has been marked for deletion
 	if !peer.ObjectMeta.DeletionTimestamp.IsZero() {
 		if hasPvcDeletionFinalizer(peer) {
 			log.V(2).Info("Deleting PVC for peer prior to deletion")

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -39,10 +39,10 @@ const (
 	pvcCleanupFinalizer = "etcdpeer.etcd.improbable.io/pvc-cleanup"
 )
 
-// +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=etcd.improbable.io,resources=etcdpeers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=list;get;create;watch
-// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=list;get;create;watch
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=list;get;create;watch;delete
 
 func initialMemberURL(member etcdv1alpha1.InitialClusterMember) *url.URL {
 	return &url.URL{

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -250,7 +250,7 @@ during which the cluster will *not be able to process write requests*.
 The etcd process running in Pod "my-cluster-2" will exit with exit-code 0, and the Pod will be marked as "Complete".
 
 Next, the operator will remove the `EtcdPeer` resource for the removed `etcd` member.
-This will trigger the deletion of the `Replicaset` and the `Pod` and the `PersistentVolumeClaim` for "my-cluster-2".
+This will trigger the deletion of the `ReplicaSet` and the `Pod` and the `PersistentVolumeClaim` for "my-cluster-2".
 The `PersistentVolume` (and the data) for the removed `etcd` node *may* be deleted
 depending on the "Reclaim Policy" of the `StorageClass` associated with the `PersistentVolume`.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -303,7 +303,7 @@ during scaling operations due to cluster leader elections, and
 at times of high network latency between Etcd peers.
 This caused Etcd containers to be restarted, which made the situation even worse.
 
-If you disagree with this or if you find a valid use-case for Readiness Probes,
+If you disagree with this or if you find a valid use-case for Liveness Probes,
 please [create an issue](https://github.com/improbable-eng/etcd-cluster-operator/issues).
 
 ### Why aren't there Readiness Probes for the Etcd Pods?

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -249,20 +249,16 @@ during which the cluster will *not be able to process write requests*.
 
 The etcd process running in Pod "my-cluster-2" will exit with exit-code 0, and the Pod will be marked as "Complete".
 
-Next, the operator will remove the `EtcdPeer` resource for the removed `etcd` member. This will trigger the deletion of
-the `Replicaset` and the `Pod`  for "my-cluster-2", but **not** the `PersistentVolumeClaim` or the `PersistentVolume`,
-for the reasons described in "### Delete a Cluster" (above).
+Next, the operator will remove the `EtcdPeer` resource for the removed `etcd` member.
+This will trigger the deletion of the `Replicaset` and the `Pod` and the `PersistentVolumeClaim` for "my-cluster-2".
+The `PersistentVolume` (and the data) for the removed `etcd` node *may* be deleted
+depending on the "Reclaim Policy" of the `StorageClass` associated with the `PersistentVolume`.
 
 When all these operations are complete the `EtcdCluster.Status` will be updated to show the new number of replicas
 and the new list of `etcd` members.
 
 Additionally, the `etcd-cluster-operator` will generate an `Event` for each operation it successfully performs,
 which allows you to track the progress of the scale down operations.
-
-If you want to scale up an `EtcdCluster` which has previously been scaled down,
-you must first remove the `PersistentVolumeClaim` associated with any `EtcdPeer` that was removed during the scale down
-operations. Otherwise new `EtcdPeer` and `Pods` will be started with `/var/lib/etcd` data corresponding to an old etcd
-member ID, and the node will fail to join the cluster.
 
 ### Backup a cluster
 
@@ -285,7 +281,7 @@ Backups can be scheduled to be taken at given intervals:
 
 ```
 $ kubectl apply -f config/samples/etcd_v1alpha1_etcdbackupschedule.yaml
-```	
+```
 
 The resource specifies a crontab-style schedule defining how often the backup should be taken.
 It includes a spec similar to the  `EtcdBackup` resource to define how the backup should be taken, and where it should be placed.
@@ -324,4 +320,3 @@ because all the Endpoints for the service would be removed when the Readiness Pr
 
 If you disagree with this or if you find a valid use-case for Readiness Probes,
 please [create an issue](https://github.com/improbable-eng/etcd-cluster-operator/issues).
-


### PR DESCRIPTION
* Add a finalizer and delete the PVC for EtcdPeer if the finalizer is present
* Add the finalizer to EtcdPeers when scaling down

Fixes: #101
Supplants: #113 