### PR TITLE
Patch rather than Update EtcdCluster.Status to avoid conflict errors

### DIFF
--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -56,6 +56,7 @@ type EtcdClusterStatus struct {
 	// (as we may have just created a peer resource that doesn't have a pod yet, or the pod could be restarting), and it
 	// doesn't mean the number of members the etcd cluster has live, as pods may not be ready yet or network problems
 	// may mean the cluster has lost a member.
+	// +optional
 	Replicas int32 `json:"replicas"`
 
 	// Members contains information about each member from the etcd cluster.

--- a/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
@@ -223,8 +223,6 @@ spec:
                 may mean the cluster has lost a member.
               format: int32
               type: integer
-          required:
-          - replicas
           type: object
       type: object
   version: v1alpha1


### PR DESCRIPTION
Avoids E2E test errors such as:
```
/tmp/etcd-e2e/teste2e-parallel-scaledown/eco-system/eco-controller-manager-5d9b759d9f-cqp5v/logs.txt:2019-12-18T17:53:14.372Z	ERROR	controllers.EtcdCluster	Failed to update status	{"cluster": "teste2e-parallel-scaledown/my-cluster", "error": "Operation cannot be fulfilled on etcdclusters.etcd.improbable.io \"my-cluster\": the object has been modified; please apply your changes to the latest version and try again"}

```

And Kubebuilder test errors such as:

```
make test ARGS="-v"
...
            log.go:31: log.V(0).WithName("EtcdCluster").Error: Failed to update status: Operation cannot be fulfilled on etcdclusters.etcd.improbable.io "cluster1": the object has been modified; please apply your changes to the latest version and try again -- [cluster special-clam/cluster1]

```

Some Kubernetes native controllers have also taken this approach. See: 
 * https://github.com/kubernetes/kubernetes/pull/77984
