### PR TITLE
Fix some race conditions

### DIFF
--- a/controllers/etcdcluster_controller_test.go
+++ b/controllers/etcdcluster_controller_test.go
@@ -341,7 +341,7 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 					ClientURLs: []string{clientURL.String()},
 				}
 			}
-			s.etcd = &StaticResponseEtcdAPI{Members: members}
+			s.setEtcd(&StaticResponseEtcdAPI{Members: members})
 
 			err = try.Eventually(func() error {
 				fetchedCluster := &etcdv1alpha1.EtcdCluster{}

--- a/controllers/etcdcluster_controller_test.go
+++ b/controllers/etcdcluster_controller_test.go
@@ -42,7 +42,7 @@ type StaticResponseMembersAPI struct {
 }
 
 func (s *StaticResponseMembersAPI) List(ctx context.Context) ([]etcdclient.Member, error) {
-	return s.parent.Members, nil
+	return s.parent.Members[:], nil
 }
 
 func (s *StaticResponseMembersAPI) Add(ctx context.Context, peerURL string) (*etcdclient.Member, error) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 )
 
 type controllerSuite struct {
+	sync.RWMutex
 	ctx       context.Context
 	cfg       *rest.Config
 	k8sClient client.Client
@@ -75,7 +77,15 @@ func setupSuite(t *testing.T) (suite *controllerSuite, teardownFunc func()) {
 // can pass ourselves in as an implementation of an EtcdAPI at test assembly time, but a test can switch out it's
 // internal implementation in the middle of a test by setting `controllerSuite.etcd`
 func (s *controllerSuite) MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error) {
+	s.RLock()
+	defer s.RUnlock()
 	return s.etcd.MembershipAPI(config)
+}
+
+func (s *controllerSuite) setEtcd(api etcd.EtcdAPI) {
+	s.Lock()
+	defer s.Unlock()
+	s.etcd = api
 }
 
 func (s *controllerSuite) setupTest(t *testing.T) (teardownFunc func(), namespaceName string) {


### PR DESCRIPTION
* Wait for controller manager to exit before exiting the test (prevents calls to t.Log after the test has finished)
* Add Lock around the setting and reading from the fake Etcd client (prevents the controller using a MembershipAPI which has been replaced in the test)
* Return a copy of the members list (prevents controller using a members list which might be mutated during the test)

The controller-runtime `manager.Start` doesn't wait for all its go-routines to finish,
which leads to another race when the controller runtime attempts to log (via t.Log) after a test has finished.
See:
 * https://github.com/uber-go/zap/issues/687#issuecomment-473382859
 * https://github.com/kubernetes-sigs/controller-runtime/issues/350

Part of: #117

