### PR TITLE
Update to controller-tools 0.2.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ controller-gen:
 ifeq (, $(shell which controller-gen))
 # Prevents go get from modifying our go.mod file.
 # See https://github.com/kubernetes-sigs/kubebuilder/issues/909
-	cd /tmp; GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.2
+	cd /tmp; GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.4
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)

--- a/config/crd/bases/etcd.improbable.io_etcdbackups.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdbackups.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.2
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: etcdbackups.etcd.improbable.io
 spec:
@@ -14,7 +14,7 @@ spec:
     listKind: EtcdBackupList
     plural: etcdbackups
     singular: etcdbackup
-  scope: ""
+  scope: Namespaced
   subresources:
     status: {}
   validation:

--- a/config/crd/bases/etcd.improbable.io_etcdbackupschedules.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdbackupschedules.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.2
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: etcdbackupschedules.etcd.improbable.io
 spec:
@@ -14,7 +14,7 @@ spec:
     listKind: EtcdBackupScheduleList
     plural: etcdbackupschedules
     singular: etcdbackupschedule
-  scope: ""
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       description: EtcdBackupSchedule is the Schema for the etcdbackupschedules API

--- a/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.2
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: etcdclusters.etcd.improbable.io
 spec:
@@ -14,7 +14,7 @@ spec:
     listKind: EtcdClusterList
     plural: etcdclusters
     singular: etcdcluster
-  scope: ""
+  scope: Namespaced
   subresources:
     scale:
       specReplicasPath: .spec.replicas

--- a/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.2
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: etcdpeers.etcd.improbable.io
 spec:
@@ -14,7 +14,7 @@ spec:
     listKind: EtcdPeerList
     plural: etcdpeers
     singular: etcdpeer
-  scope: ""
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       description: EtcdPeer is the Schema for the etcdpeers API


### PR DESCRIPTION
We need this version for the new // +kubebuilder:pruning:PreserveUnknownFields annotation.


Part of: #116