### PR TITLE
Configurable Etcd Image

### DIFF
--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -7,6 +7,10 @@ import (
 
 // EtcdClusterSpec defines the desired state of EtcdCluster
 type EtcdClusterSpec struct {
+	// Image is the Docker image which will be used for each EtcdPeer.
+	//+kubebuilder:validation:Required
+	Image string `json:"image"`
+
 	// Number of instances of etcd to assemble into this cluster
 	//+kubebuilder:validation:Required
 	//+kubebuilder:validation:Minimum=1

--- a/api/v1alpha1/etcdpeer_types.go
+++ b/api/v1alpha1/etcdpeer_types.go
@@ -51,6 +51,10 @@ type Bootstrap struct {
 
 // EtcdPeerSpec defines the desired state of EtcdPeer
 type EtcdPeerSpec struct {
+	// Image is the Docker image which will be used for each EtcdPeer.
+	//+kubebuilder:validation:Required
+	Image string `json:"image"`
+
 	// The name of the etcd cluster that this peer should join. This will be
 	// used to set the `spec.subdomain` field and the
 	// `etcd.improbable.io/cluster-name` label on the Pod running etcd.

--- a/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
@@ -39,6 +39,9 @@ spec:
         spec:
           description: EtcdClusterSpec defines the desired state of EtcdCluster
           properties:
+            image:
+              description: Image is the Docker image which will be used for each EtcdPeer.
+              type: string
             podTemplate:
               description: PodTemplate describes metadata that should be applied to
                 the underlying Pods. This may not be applied verbatim, as additional
@@ -208,6 +211,7 @@ spec:
                   type: object
               type: object
           required:
+          - image
           - replicas
           type: object
         status:

--- a/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
@@ -90,6 +90,9 @@ spec:
                 label on the Pod running etcd.
               maxLength: 64
               type: string
+            image:
+              description: Image is the Docker image which will be used for each EtcdPeer.
+              type: string
             podTemplate:
               description: PodTemplate describes metadata that should be applied to
                 the underlying Pods. This may not be applied verbatim, as additional
@@ -255,6 +258,7 @@ spec:
               type: object
           required:
           - clusterName
+          - image
           type: object
         status:
           description: EtcdPeerStatus defines the observed state of EtcdPeer

--- a/config/samples/etcd_v1alpha1_etcdcluster.yaml
+++ b/config/samples/etcd_v1alpha1_etcdcluster.yaml
@@ -3,6 +3,7 @@ kind: EtcdCluster
 metadata:
   name: my-cluster
 spec:
+  image: "quay.io/coreos/etcd:v3.2.28"
   replicas: 3
   storage:
     volumeClaimTemplate:

--- a/config/samples/etcd_v1alpha1_etcdpeer.yaml
+++ b/config/samples/etcd_v1alpha1_etcdpeer.yaml
@@ -3,6 +3,7 @@ kind: EtcdPeer
 metadata:
   name: etcdpeer-sample
 spec:
+  image: "quay.io/coreos/etcd:v3.2.28"
   clusterName: bees
   storage:
     volumeClaimTemplate:

--- a/config/test/e2e/backup/etcdcluster.yaml
+++ b/config/test/e2e/backup/etcdcluster.yaml
@@ -3,6 +3,7 @@ kind: EtcdCluster
 metadata:
   name: e2e-backup-cluster
 spec:
+  image: "quay.io/coreos/etcd:v3.2.28"
   replicas: 1
   storage:
     volumeClaimTemplate:

--- a/config/test/e2e/defaulting/etcdcluster.yaml
+++ b/config/test/e2e/defaulting/etcdcluster.yaml
@@ -3,6 +3,7 @@ kind: EtcdCluster
 metadata:
   name: e2e-defaulting-cluster
 spec:
+  image: "quay.io/coreos/etcd:v3.2.28"
   replicas: 1
   storage:
     volumeClaimTemplate:

--- a/config/test/e2e/defaulting/etcdpeer.yaml
+++ b/config/test/e2e/defaulting/etcdpeer.yaml
@@ -3,6 +3,7 @@ kind: EtcdPeer
 metadata:
   name: e2e-defaulting-peer
 spec:
+  image: "quay.io/coreos/etcd:v3.2.28"
   clusterName: e2e-defaulting-peer
   storage:
     volumeClaimTemplate:

--- a/config/test/e2e/persistence/cluster.yaml
+++ b/config/test/e2e/persistence/cluster.yaml
@@ -3,6 +3,7 @@ kind: EtcdCluster
 metadata:
   name: cluster1
 spec:
+  image: "quay.io/coreos/etcd:v3.2.28"
   replicas: 1
   storage:
     volumeClaimTemplate:

--- a/config/test/e2e/validation/etcdcluster_missing_storageclassname.yaml
+++ b/config/test/e2e/validation/etcdcluster_missing_storageclassname.yaml
@@ -5,6 +5,7 @@ kind: EtcdCluster
 metadata:
   name: e2e-defaulting-cluster
 spec:
+  image: "quay.io/coreos/etcd:v3.2.28"
   replicas: 1
   storage:
     volumeClaimTemplate:

--- a/config/test/e2e/validation/etcdpeer_missing_storageclassname.yaml
+++ b/config/test/e2e/validation/etcdpeer_missing_storageclassname.yaml
@@ -5,6 +5,7 @@ kind: EtcdPeer
 metadata:
   name: e2e-defaulting-peer
 spec:
+  image: "quay.io/coreos/etcd:v3.2.28"
   clusterName: e2e-defaulting-peer
   storage:
     volumeClaimTemplate:

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -623,6 +623,7 @@ func peerForCluster(cluster *etcdv1alpha1.EtcdCluster, peerName string) *etcdv1a
 			},
 		},
 		Spec: etcdv1alpha1.EtcdPeerSpec{
+			Image:       cluster.Spec.Image,
 			ClusterName: cluster.Name,
 			Storage:     cluster.Spec.Storage.DeepCopy(),
 		},

--- a/controllers/etcdcluster_controller_test.go
+++ b/controllers/etcdcluster_controller_test.go
@@ -250,9 +250,11 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 		defer teardownFunc()
 
 		const expectedReplicas = 3
+		const expectedImage = "registry1/etcd:v1.2.3@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
 
 		etcdCluster := test.ExampleEtcdCluster(namespace)
 		etcdCluster.Spec.Replicas = pointer.Int32Ptr(expectedReplicas)
+		etcdCluster.Spec.Image = expectedImage
 
 		err := s.k8sClient.Create(s.ctx, etcdCluster)
 		require.NoError(t, err, "failed to create EtcdCluster resource")
@@ -525,6 +527,7 @@ func assertPeer(t *testing.T, cluster *etcdv1alpha1.EtcdCluster, peer *etcdv1alp
 	assertOwnedByCluster(t, cluster, peer)
 
 	assert.Equal(t, cluster.Spec.Storage, peer.Spec.Storage, "unexpected peer storage")
+	assert.Equal(t, cluster.Spec.Image, peer.Spec.Image, "unexpected image")
 }
 
 func expectedStatusForCluster(c etcdv1alpha1.EtcdCluster) etcdv1alpha1.EtcdClusterStatus {

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -35,7 +35,6 @@ type EtcdPeerReconciler struct {
 }
 
 const (
-	etcdImage           = "quay.io/coreos/etcd:v3.2.28"
 	etcdScheme          = "http"
 	peerLabel           = "etcd.improbable.io/peer-name"
 	pvcCleanupFinalizer = "etcdpeer.etcd.improbable.io/pvc-cleanup"
@@ -133,7 +132,7 @@ func defineReplicaSet(peer etcdv1alpha1.EtcdPeer, log logr.Logger) appsv1.Replic
 
 	etcdContainer := corev1.Container{
 		Name:  appName,
-		Image: etcdImage,
+		Image: peer.Spec.Image,
 		Env: []corev1.EnvVar{
 			{
 				Name:  etcdenvvar.InitialCluster,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,6 +14,12 @@ mechanism capable of modifying and viewing Kubernetes resources.
 To create a new cluster, create an `EtcdCluster` resource in the namespace you want the cluster's pods to run in. The
 `spec` field of the resource is used to configure the desired properties of the cluster.
 
+### Image
+
+The `spec.image` field determines which Docker image is used for each  `EtcdPeer` created by the operator.
+This field is immutable.
+Image changes are not yet supported.
+
 ### Replicas
 
 The `spec.replicas` field determines the number of pods that are run in the etcd cluster.

--- a/internal/test/examples.go
+++ b/internal/test/examples.go
@@ -19,6 +19,7 @@ func ExampleEtcdCluster(namespace string) *etcdv1alpha1.EtcdCluster {
 			Namespace: namespace,
 		},
 		Spec: etcdv1alpha1.EtcdClusterSpec{
+			Image:    "quay.io/coreos/etcd:v3.2.28",
 			Replicas: pointer.Int32Ptr(3),
 			Storage: &etcdv1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
@@ -54,6 +55,7 @@ func ExampleEtcdPeer(namespace string) *etcdv1alpha1.EtcdPeer {
 			Namespace: namespace,
 		},
 		Spec: etcdv1alpha1.EtcdPeerSpec{
+			Image:       "quay.io/coreos/etcd:v3.2.28",
 			ClusterName: "my-cluster",
 			Bootstrap: &etcdv1alpha1.Bootstrap{
 				Static: &etcdv1alpha1.StaticBootstrap{


### PR DESCRIPTION
Part of: #98

This is a first step.
Next I'll try and use the Etcd client to discover the version reported by each Etcd Member and add that to the EtcdClusterStatus and EtcdPeerStatus.

Then I should be able to:
 * add a new Spec.Version field to configure the desired semantic version,
 * add a new EtcdCluster health check in the reconciler which checks that all the peers are reporting the version in the spec.
 * and finally update the  validation to only allow patch version upgrades
 * and update EtcdPeer reconcile function to restart the Replicasets when the version changes.


....something like that.