### PR TITLE
EtcdCluster.Status.APIVersion

### DIFF
--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -67,6 +67,9 @@ type EtcdClusterStatus struct {
 	// Members contains information about each member from the etcd cluster.
 	// +optional
 	Members []EtcdMember `json:"members"`
+
+	// APIVersion contains the cluster API version
+	APIVersion string `json:"apiVersion"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -113,7 +113,12 @@ func TestEtcdCluster_ValidateUpdate(t *testing.T) {
 		{
 			name: "UnsupportedChange/ResourcesStorage",
 			modifier: func(o *v1alpha1.EtcdCluster) {
-				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = resource.MustParse("1Mi")
+				storage, found := o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"]
+				if !found {
+					panic("A storage request must be set for this test")
+				}
+				storage.Add(resource.MustParse("1Mi"))
+				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = storage
 			},
 			err: `^Unsupported changes:`,
 		},
@@ -212,7 +217,12 @@ func TestEtcdPeer_ValidateUpdate(t *testing.T) {
 		{
 			name: "UnsupportedChange/ResourcesStorage",
 			modifier: func(o *v1alpha1.EtcdPeer) {
-				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = resource.MustParse("1Mi")
+				storage, found := o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"]
+				if !found {
+					panic("A storage request must be set for this test")
+				}
+				storage.Add(resource.MustParse("1Mi"))
+				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = storage
 			},
 			err: `^Unsupported changes:`,
 		},

--- a/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
@@ -213,6 +213,9 @@ spec:
         status:
           description: EtcdClusterStatus defines the observed state of EtcdCluster
           properties:
+            apiVersion:
+              description: APIVersion contains the cluster API version
+              type: string
             members:
               description: Members contains information about each member from the
                 etcd cluster.
@@ -243,6 +246,7 @@ spec:
               format: int32
               type: integer
           required:
+          - apiVersion
           - replicas
           type: object
       type: object

--- a/controllers/etcdbackupschedule_controller_test.go
+++ b/controllers/etcdbackupschedule_controller_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *controllerSuite) testBackupScheduleController(t *testing.T) {
-	teardownFunc, namespace := s.setupTest(t)
+	teardownFunc, namespace := s.setupTest(t, &AlwaysFailEtcdAPI{})
 	defer teardownFunc()
 
 	backupSchedule := test.ExampleEtcdBackupSchedule(namespace)

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -36,7 +36,7 @@ type EtcdClusterReconciler struct {
 	client.Client
 	Log      logr.Logger
 	Recorder record.EventRecorder
-	Etcd     etcd.EtcdAPI
+	Etcd     etcd.APIBuilder
 }
 
 func headlessServiceForCluster(cluster *etcdv1alpha1.EtcdCluster) *v1.Service {
@@ -537,7 +537,7 @@ func (r *EtcdClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 }
 
 func (r *EtcdClusterReconciler) addEtcdMember(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster, peerURL string) (*etcdclient.Member, error) {
-	c, err := r.Etcd.MembershipAPI(etcdClientConfig(cluster))
+	c, err := r.Etcd.New(etcdClientConfig(cluster))
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to etcd: %w", err)
 	}
@@ -553,7 +553,7 @@ func (r *EtcdClusterReconciler) addEtcdMember(ctx context.Context, cluster *etcd
 // removeEtcdMember performs a runtime reconfiguration of the Etcd cluster to
 // remove a member from the cluster.
 func (r *EtcdClusterReconciler) removeEtcdMember(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster, memberID string) error {
-	c, err := r.Etcd.MembershipAPI(etcdClientConfig(cluster))
+	c, err := r.Etcd.New(etcdClientConfig(cluster))
 	if err != nil {
 		return fmt.Errorf("unable to connect to etcd: %w", err)
 	}
@@ -566,7 +566,7 @@ func (r *EtcdClusterReconciler) removeEtcdMember(ctx context.Context, cluster *e
 }
 
 func (r *EtcdClusterReconciler) getEtcdMembers(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster) ([]etcdclient.Member, error) {
-	c, err := r.Etcd.MembershipAPI(etcdClientConfig(cluster))
+	c, err := r.Etcd.New(etcdClientConfig(cluster))
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to etcd: %w", err)
 	}

--- a/controllers/etcdpeer_controller_test.go
+++ b/controllers/etcdpeer_controller_test.go
@@ -36,7 +36,7 @@ func exampleEtcdPeer(namespace string) *etcdv1alpha1.EtcdPeer {
 
 func (s *controllerSuite) testPeerController(t *testing.T) {
 	t.Run("TestPeerController_OnCreation_CreatesReplicaSet", func(t *testing.T) {
-		teardownFunc, namespace := s.setupTest(t)
+		teardownFunc, namespace := s.setupTest(t, &AlwaysFailEtcdAPI{})
 		defer teardownFunc()
 
 		etcdPeer := exampleEtcdPeer(namespace)
@@ -137,7 +137,7 @@ func (s *controllerSuite) testPeerController(t *testing.T) {
 		)
 	})
 	t.Run("CreatesPersistentVolumeClaim", func(t *testing.T) {
-		teardown, namespace := s.setupTest(t)
+		teardown, namespace := s.setupTest(t, &AlwaysFailEtcdAPI{})
 		defer teardown()
 		peer := exampleEtcdPeer(namespace)
 		err := s.k8sClient.Create(s.ctx, peer)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ replace (
 require (
 	cloud.google.com/go v0.38.0
 	github.com/coreos/etcd v3.3.17+incompatible
+	github.com/coreos/go-semver v0.3.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20190613200456-11339a705ed2
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.3.0

--- a/internal/etcd/etcd.go
+++ b/internal/etcd/etcd.go
@@ -3,6 +3,7 @@ package etcd
 import (
 	"context"
 
+	"github.com/coreos/etcd/version"
 	etcdclient "go.etcd.io/etcd/client"
 )
 
@@ -17,6 +18,9 @@ type API interface {
 
 	// Remove demotes an existing Member out of the cluster.
 	Remove(ctx context.Context, mID string) error
+
+	// GetVersion retrieves the current etcd server and cluster version
+	GetVersion(ctx context.Context) (*version.Versions, error)
 }
 
 // APIBuilder is used to connect to etcd in the first place
@@ -26,6 +30,7 @@ type APIBuilder interface {
 
 type ClientEtcdAPI struct {
 	etcdclient.MembersAPI
+	etcdclient.Client
 }
 
 var _ API = &ClientEtcdAPI{}
@@ -41,5 +46,6 @@ func (o *ClientEtcdAPIBuilder) New(config etcdclient.Config) (API, error) {
 	}
 	return &ClientEtcdAPI{
 		MembersAPI: etcdclient.NewMembersAPI(client),
+		Client:     client,
 	}, nil
 }

--- a/internal/etcd/etcd.go
+++ b/internal/etcd/etcd.go
@@ -1,22 +1,45 @@
 package etcd
 
 import (
+	"context"
+
 	etcdclient "go.etcd.io/etcd/client"
 )
 
-// EtcdDailer is used to connect to etcd in the first place
-type EtcdAPI interface {
-	// Give an API that provides access to etcd membership API functions.
-	MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error)
+// API contains only the ETCD APIs that we use in the operator
+// to allow for testing fakes.
+type API interface {
+	// List enumerates the current cluster membership.
+	List(ctx context.Context) ([]etcdclient.Member, error)
+
+	// Add instructs etcd to accept a new Member into the cluster.
+	Add(ctx context.Context, peerURL string) (*etcdclient.Member, error)
+
+	// Remove demotes an existing Member out of the cluster.
+	Remove(ctx context.Context, mID string) error
 }
 
-type ClientEtcdAPI struct{}
+// APIBuilder is used to connect to etcd in the first place
+type APIBuilder interface {
+	New(etcdclient.Config) (API, error)
+}
 
-func (_ *ClientEtcdAPI) MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error) {
+type ClientEtcdAPI struct {
+	etcdclient.MembersAPI
+}
+
+var _ API = &ClientEtcdAPI{}
+
+type ClientEtcdAPIBuilder struct{}
+
+var _ APIBuilder = &ClientEtcdAPIBuilder{}
+
+func (o *ClientEtcdAPIBuilder) New(config etcdclient.Config) (API, error) {
 	client, err := etcdclient.New(config)
 	if err != nil {
 		return nil, err
 	}
-
-	return etcdclient.NewMembersAPI(client), nil
+	return &ClientEtcdAPI{
+		MembersAPI: etcdclient.NewMembersAPI(client),
+	}, nil
 }

--- a/internal/test/examples.go
+++ b/internal/test/examples.go
@@ -14,6 +14,10 @@ import (
 // ExampleEtcdCluster returns a valid example for testing purposes.
 func ExampleEtcdCluster(namespace string) *etcdv1alpha1.EtcdCluster {
 	return &etcdv1alpha1.EtcdCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "EtcdCluster",
+			APIVersion: "etcd.improbable.io/v1alpha1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster1",
 			Namespace: namespace,
@@ -22,10 +26,10 @@ func ExampleEtcdCluster(namespace string) *etcdv1alpha1.EtcdCluster {
 			Replicas: pointer.Int32Ptr(3),
 			Storage: &etcdv1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
-					StorageClassName: pointer.StringPtr("example-class"),
+					StorageClassName: pointer.StringPtr("standard"),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"storage": resource.MustParse("999Gi"),
+							"storage": resource.MustParse("1Mi"),
 						},
 					},
 				},
@@ -76,10 +80,10 @@ func ExampleEtcdPeer(namespace string) *etcdv1alpha1.EtcdPeer {
 			},
 			Storage: &etcdv1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
-					StorageClassName: pointer.StringPtr("example-class"),
+					StorageClassName: pointer.StringPtr("standard"),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"storage": resource.MustParse("999Gi"),
+							"storage": resource.MustParse("1Mi"),
 						},
 					},
 				},

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("EtcdCluster"),
 		Recorder: mgr.GetEventRecorderFor("etcdcluster-reconciler"),
-		Etcd:     &etcd.ClientEtcdAPI{},
+		Etcd:     &etcd.ClientEtcdAPIBuilder{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EtcdCluster")
 		os.Exit(1)


### PR DESCRIPTION
* Refactored our internal Etcd API so that I can more easily include the GetVersion method.
* Publish the "Cluster" version to `EtcdCluster.Status.APIVersion`. This is equivalent to the API version which is returned by `etcdctl version`

```
kubectl -n teste2e-parallel-version exec cluster1-0-whcn9 -- sh -c 'ETCDCTL_API=3 etcdctl version'
etcdctl version: 3.2.28
API version: 3.2

```