### PR TITLE
Refactor the ETCD API and test fakes

### DIFF
--- a/controllers/etcdbackupschedule_controller_test.go
+++ b/controllers/etcdbackupschedule_controller_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *controllerSuite) testBackupScheduleController(t *testing.T) {
-	teardownFunc, namespace := s.setupTest(t)
+	teardownFunc, namespace := s.setupTest(t, &AlwaysFailEtcdAPI{})
 	defer teardownFunc()
 
 	backupSchedule := test.ExampleEtcdBackupSchedule(namespace)

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -36,7 +36,7 @@ type EtcdClusterReconciler struct {
 	client.Client
 	Log      logr.Logger
 	Recorder record.EventRecorder
-	Etcd     etcd.EtcdAPI
+	Etcd     etcd.APIBuilder
 }
 
 func headlessServiceForCluster(cluster *etcdv1alpha1.EtcdCluster) *v1.Service {
@@ -537,7 +537,7 @@ func (r *EtcdClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 }
 
 func (r *EtcdClusterReconciler) addEtcdMember(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster, peerURL string) (*etcdclient.Member, error) {
-	c, err := r.Etcd.MembershipAPI(etcdClientConfig(cluster))
+	c, err := r.Etcd.New(etcdClientConfig(cluster))
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to etcd: %w", err)
 	}
@@ -553,7 +553,7 @@ func (r *EtcdClusterReconciler) addEtcdMember(ctx context.Context, cluster *etcd
 // removeEtcdMember performs a runtime reconfiguration of the Etcd cluster to
 // remove a member from the cluster.
 func (r *EtcdClusterReconciler) removeEtcdMember(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster, memberID string) error {
-	c, err := r.Etcd.MembershipAPI(etcdClientConfig(cluster))
+	c, err := r.Etcd.New(etcdClientConfig(cluster))
 	if err != nil {
 		return fmt.Errorf("unable to connect to etcd: %w", err)
 	}
@@ -566,7 +566,7 @@ func (r *EtcdClusterReconciler) removeEtcdMember(ctx context.Context, cluster *e
 }
 
 func (r *EtcdClusterReconciler) getEtcdMembers(ctx context.Context, cluster *etcdv1alpha1.EtcdCluster) ([]etcdclient.Member, error) {
-	c, err := r.Etcd.MembershipAPI(etcdClientConfig(cluster))
+	c, err := r.Etcd.New(etcdClientConfig(cluster))
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to etcd: %w", err)
 	}

--- a/controllers/etcdpeer_controller_test.go
+++ b/controllers/etcdpeer_controller_test.go
@@ -36,7 +36,7 @@ func exampleEtcdPeer(namespace string) *etcdv1alpha1.EtcdPeer {
 
 func (s *controllerSuite) testPeerController(t *testing.T) {
 	t.Run("TestPeerController_OnCreation_CreatesReplicaSet", func(t *testing.T) {
-		teardownFunc, namespace := s.setupTest(t)
+		teardownFunc, namespace := s.setupTest(t, &AlwaysFailEtcdAPI{})
 		defer teardownFunc()
 
 		etcdPeer := exampleEtcdPeer(namespace)
@@ -137,7 +137,7 @@ func (s *controllerSuite) testPeerController(t *testing.T) {
 		)
 	})
 	t.Run("CreatesPersistentVolumeClaim", func(t *testing.T) {
-		teardown, namespace := s.setupTest(t)
+		teardown, namespace := s.setupTest(t, &AlwaysFailEtcdAPI{})
 		defer teardown()
 		peer := exampleEtcdPeer(namespace)
 		err := s.k8sClient.Create(s.ctx, peer)

--- a/internal/etcd/etcd.go
+++ b/internal/etcd/etcd.go
@@ -1,22 +1,45 @@
 package etcd
 
 import (
+	"context"
+
 	etcdclient "go.etcd.io/etcd/client"
 )
 
-// EtcdDailer is used to connect to etcd in the first place
-type EtcdAPI interface {
-	// Give an API that provides access to etcd membership API functions.
-	MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error)
+// API contains only the ETCD APIs that we use in the operator
+// to allow for testing fakes.
+type API interface {
+	// List enumerates the current cluster membership.
+	List(ctx context.Context) ([]etcdclient.Member, error)
+
+	// Add instructs etcd to accept a new Member into the cluster.
+	Add(ctx context.Context, peerURL string) (*etcdclient.Member, error)
+
+	// Remove demotes an existing Member out of the cluster.
+	Remove(ctx context.Context, mID string) error
 }
 
-type ClientEtcdAPI struct{}
+// APIBuilder is used to connect to etcd in the first place
+type APIBuilder interface {
+	New(etcdclient.Config) (API, error)
+}
 
-func (_ *ClientEtcdAPI) MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error) {
+type ClientEtcdAPI struct {
+	etcdclient.MembersAPI
+}
+
+var _ API = &ClientEtcdAPI{}
+
+type ClientEtcdAPIBuilder struct{}
+
+var _ APIBuilder = &ClientEtcdAPIBuilder{}
+
+func (o *ClientEtcdAPIBuilder) New(config etcdclient.Config) (API, error) {
 	client, err := etcdclient.New(config)
 	if err != nil {
 		return nil, err
 	}
-
-	return etcdclient.NewMembersAPI(client), nil
+	return &ClientEtcdAPI{
+		MembersAPI: etcdclient.NewMembersAPI(client),
+	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("EtcdCluster"),
 		Recorder: mgr.GetEventRecorderFor("etcdcluster-reconciler"),
-		Etcd:     &etcd.ClientEtcdAPI{},
+		Etcd:     &etcd.ClientEtcdAPIBuilder{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EtcdCluster")
 		os.Exit(1)


### PR DESCRIPTION
I hope this makes it clearer to see how the fake ETCD API is used and injected.

Extracted from: #138 
