### PR TITLE
EtcdCluster.Status.ClusterVersion and EtcdPeer.Status.ServerVersion

### DIFF
--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -68,6 +68,10 @@ type EtcdClusterStatus struct {
 	// Members contains information about each member from the etcd cluster.
 	// +optional
 	Members []EtcdMember `json:"members"`
+
+	// ClusterVersion contains the cluster API version
+	// +optional
+	ClusterVersion string `json:"clusterVersion"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/etcdpeer_types.go
+++ b/api/v1alpha1/etcdpeer_types.go
@@ -86,9 +86,12 @@ type EtcdPeerStorage struct {
 
 // EtcdPeerStatus defines the observed state of EtcdPeer
 type EtcdPeerStatus struct {
+	// ServerVersion contains the Member server version
+	ServerVersion string `json:"serverVersion"`
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // EtcdPeer is the Schema for the etcdpeers API
 type EtcdPeer struct {

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -113,7 +113,12 @@ func TestEtcdCluster_ValidateUpdate(t *testing.T) {
 		{
 			name: "UnsupportedChange/ResourcesStorage",
 			modifier: func(o *v1alpha1.EtcdCluster) {
-				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = resource.MustParse("1Mi")
+				storage, found := o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"]
+				if !found {
+					panic("A storage request must be set for this test")
+				}
+				storage.Add(resource.MustParse("1Mi"))
+				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = storage
 			},
 			err: `^Unsupported changes:`,
 		},
@@ -212,7 +217,12 @@ func TestEtcdPeer_ValidateUpdate(t *testing.T) {
 		{
 			name: "UnsupportedChange/ResourcesStorage",
 			modifier: func(o *v1alpha1.EtcdPeer) {
-				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = resource.MustParse("1Mi")
+				storage, found := o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"]
+				if !found {
+					panic("A storage request must be set for this test")
+				}
+				storage.Add(resource.MustParse("1Mi"))
+				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = storage
 			},
 			err: `^Unsupported changes:`,
 		},

--- a/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
@@ -213,6 +213,9 @@ spec:
         status:
           description: EtcdClusterStatus defines the observed state of EtcdCluster
           properties:
+            clusterVersion:
+              description: ClusterVersion contains the cluster API version
+              type: string
             members:
               description: Members contains information about each member from the
                 etcd cluster.

--- a/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
@@ -15,6 +15,8 @@ spec:
     plural: etcdpeers
     singular: etcdpeer
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: EtcdPeer is the Schema for the etcdpeers API
@@ -258,6 +260,12 @@ spec:
           type: object
         status:
           description: EtcdPeerStatus defines the observed state of EtcdPeer
+          properties:
+            serverVersion:
+              description: ServerVersion contains the Member server version
+              type: string
+          required:
+          - serverVersion
           type: object
       type: object
   version: v1alpha1

--- a/controllers/etcdbackupschedule_controller_test.go
+++ b/controllers/etcdbackupschedule_controller_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *controllerSuite) testBackupScheduleController(t *testing.T) {
-	teardownFunc, namespace := s.setupTest(t)
+	teardownFunc, namespace := s.setupTest(t, &AlwaysFailEtcdAPI{})
 	defer teardownFunc()
 
 	backupSchedule := test.ExampleEtcdBackupSchedule(namespace)

--- a/controllers/etcdcluster_controller_test.go
+++ b/controllers/etcdcluster_controller_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/etcd/version"
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,23 +26,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
+	"github.com/improbable-eng/etcd-cluster-operator/internal/etcd"
 	"github.com/improbable-eng/etcd-cluster-operator/internal/test"
 	"github.com/improbable-eng/etcd-cluster-operator/internal/test/try"
 )
 
 type AlwaysFailEtcdAPI struct{}
 
-func (_ *AlwaysFailEtcdAPI) MembershipAPI(_ etcdclient.Config) (etcdclient.MembersAPI, error) {
-	return nil, errors.New("fake etcd, nothing is here")
-}
+var _ etcd.APIBuilder = &AlwaysFailEtcdAPI{}
 
-// StaticResponseMembersAPI can be injected into the etcdcluster_controller for
-// testing the interactions with the Etcd client API.
-// The `parent` field is a pointer so that a test and the controller-under-test see the
-// same shared Members list.
-type StaticResponseMembersAPI struct {
-	sync.RWMutex
-	parent *StaticResponseEtcdAPI
+func (_ *AlwaysFailEtcdAPI) New(_ etcdclient.Config) (etcd.API, error) {
+	return nil, errors.New("fake etcd, nothing is here")
 }
 
 // deepCopyEtcdClientMember makes a copy of the supplied Member
@@ -53,12 +49,29 @@ func deepCopyEtcdClientMember(in etcdclient.Member) (out etcdclient.Member, err 
 	return out, err
 }
 
-func (s *StaticResponseMembersAPI) List(ctx context.Context) ([]etcdclient.Member, error) {
+// StaticResponseEtcdAPI can be injected into the etcdcluster_controller for
+// testing the interactions with the Etcd client API.
+type StaticResponseEtcdAPI struct {
+	sync.RWMutex
+	Members        []etcdclient.Member
+	ClusterVersion string
+	ServerVersion  string
+}
+
+var _ etcd.APIBuilder = &StaticResponseEtcdAPI{}
+
+func (s *StaticResponseEtcdAPI) New(config etcdclient.Config) (etcd.API, error) {
+	return s, nil
+}
+
+var _ etcd.API = &StaticResponseEtcdAPI{}
+
+func (s *StaticResponseEtcdAPI) List(ctx context.Context) ([]etcdclient.Member, error) {
 	s.RLock()
 	defer s.RUnlock()
-	out := make([]etcdclient.Member, len(s.parent.Members))
+	out := make([]etcdclient.Member, len(s.Members))
 	for i := 0; i < len(out); i++ {
-		new, err := deepCopyEtcdClientMember(s.parent.Members[i])
+		new, err := deepCopyEtcdClientMember(s.Members[i])
 		if err != nil {
 			return nil, err
 		}
@@ -67,42 +80,50 @@ func (s *StaticResponseMembersAPI) List(ctx context.Context) ([]etcdclient.Membe
 	return out, nil
 }
 
-func (s *StaticResponseMembersAPI) Add(ctx context.Context, peerURL string) (*etcdclient.Member, error) {
+func (s *StaticResponseEtcdAPI) Add(ctx context.Context, peerURL string) (*etcdclient.Member, error) {
 	s.Lock()
 	defer s.Unlock()
 	panic("implement me")
 }
 
-func (s *StaticResponseMembersAPI) Remove(ctx context.Context, mID string) error {
+func (s *StaticResponseEtcdAPI) Remove(ctx context.Context, mID string) error {
 	s.Lock()
 	defer s.Unlock()
-	for i := range s.parent.Members {
-		if s.parent.Members[i].ID == mID {
-			s.parent.Members = append(s.parent.Members[:i], s.parent.Members[i+1:]...)
+	for i := range s.Members {
+		if s.Members[i].ID == mID {
+			s.Members = append(s.Members[:i], s.Members[i+1:]...)
 			return nil
 		}
 	}
 	return fmt.Errorf("unknown member: %s", mID)
 }
 
-func (s *StaticResponseMembersAPI) Update(ctx context.Context, mID string, peerURLs []string) error {
-	s.Lock()
-	defer s.Unlock()
-	panic("implement me")
-}
-
-func (s *StaticResponseMembersAPI) Leader(ctx context.Context) (*etcdclient.Member, error) {
+func (s *StaticResponseEtcdAPI) GetVersion(ctx context.Context) (*version.Versions, error) {
 	s.RLock()
 	defer s.RUnlock()
-	panic("implement me")
+	return &version.Versions{
+		Cluster: s.ClusterVersion,
+		Server:  s.ServerVersion,
+	}, nil
 }
 
-type StaticResponseEtcdAPI struct {
-	Members []etcdclient.Member
+type WrapperEtcdAPI struct {
+	sync.RWMutex
+	wrapped etcd.APIBuilder
 }
 
-func (sr *StaticResponseEtcdAPI) MembershipAPI(_ etcdclient.Config) (etcdclient.MembersAPI, error) {
-	return &StaticResponseMembersAPI{parent: sr}, nil
+var _ etcd.APIBuilder = &WrapperEtcdAPI{}
+
+func (o *WrapperEtcdAPI) New(config etcdclient.Config) (etcd.API, error) {
+	o.RLock()
+	defer o.RUnlock()
+	return o.wrapped.New(config)
+}
+
+func (o *WrapperEtcdAPI) Wrap(wrapped etcd.APIBuilder) {
+	o.Lock()
+	defer o.Unlock()
+	o.wrapped = wrapped
 }
 
 // fakeEtcdForEtcdCluster returns a fake MembersAPI which simulates an Etcd API
@@ -143,7 +164,9 @@ func fakeEtcdForEtcdCluster(etcdCluster etcdv1alpha1.EtcdCluster) *StaticRespons
 func (s *controllerSuite) testClusterController(t *testing.T) {
 	t.Run("ScaleDown", func(t *testing.T) {
 		t.Log("Setup.")
-		teardownFunc, namespace := s.setupTest(t)
+		etcdAPI := &WrapperEtcdAPI{wrapped: &AlwaysFailEtcdAPI{}}
+
+		teardownFunc, namespace := s.setupTest(t, etcdAPI)
 		defer teardownFunc()
 
 		etcdCluster := test.ExampleEtcdCluster(namespace)
@@ -152,13 +175,10 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 		etcdCluster.Default()
 
 		const originalReplicas = 3
-		const expectedReplicas = 1
 
 		*etcdCluster.Spec.Replicas = originalReplicas
-
-		// Give the operator a fake Etcdclient which simulates an established
-		// healthy cluster.
-		s.etcd = fakeEtcdForEtcdCluster(*etcdCluster)
+		etcdAPIStatic := fakeEtcdForEtcdCluster(*etcdCluster)
+		etcdAPI.Wrap(etcdAPIStatic)
 
 		t.Log("Given an established 3-node cluster.")
 		err := s.k8sClient.Create(s.ctx, etcdCluster)
@@ -208,7 +228,7 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 		})
 		t.Run("EtcdMembersUpdate", func(t *testing.T) {
 			t.Log("The etcd cluster API reports the expected number of nodes")
-			membership, err := s.etcd.MembershipAPI(etcdclient.Config{})
+			membership, err := etcdAPI.New(etcdclient.Config{})
 			require.NoError(t, err)
 			expectedMembers := expectedEtcdMembersForCluster(*etcdCluster)
 			err = try.Eventually(func() error {
@@ -246,7 +266,11 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 	})
 
 	t.Run("OnCreation", func(t *testing.T) {
-		teardownFunc, namespace := s.setupTest(t)
+		// Mock out the etcd API with one that always fails - i.e., we're always
+		// in 'bootstrap' mode.
+		// But use a wrapper so that the implementation can be switched later.
+		etcdAPI := &WrapperEtcdAPI{wrapped: &AlwaysFailEtcdAPI{}}
+		teardownFunc, namespace := s.setupTest(t, etcdAPI)
 		defer teardownFunc()
 
 		const expectedReplicas = 3
@@ -260,9 +284,6 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 		// Apply defaults here so that our expected object has all the same
 		// defaults as those used in the Reconcile function
 		etcdCluster.Default()
-
-		// Mock out the etcd API with one that always fails - i.e., we're always in 'bootstrap' mode
-		s.etcd = &AlwaysFailEtcdAPI{}
 
 		t.Run("CreatesService", func(t *testing.T) {
 			service := &v1.Service{}
@@ -376,7 +397,10 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 					ClientURLs: []string{clientURL.String()},
 				}
 			}
-			s.setEtcd(&StaticResponseEtcdAPI{Members: members})
+
+			// Swap the wrapped implementation, to one which responds with a
+			// fixed list of members
+			etcdAPI.Wrap(&StaticResponseEtcdAPI{Members: members})
 
 			err = try.Eventually(func() error {
 				fetchedCluster := &etcdv1alpha1.EtcdCluster{}
@@ -410,7 +434,8 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 	})
 
 	t.Run("PodAnnotations", func(t *testing.T) {
-		teardownFunc, namespace := s.setupTest(t)
+		// Mock out the etcd API with one that always fails - i.e., we're always in 'bootstrap' mode
+		teardownFunc, namespace := s.setupTest(t, &AlwaysFailEtcdAPI{})
 		defer teardownFunc()
 
 		etcdCluster := test.ExampleEtcdCluster(namespace)
@@ -432,9 +457,6 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 		// Apply defaults here so that our expected object has all the same
 		// defaults as those used in the Reconcile function
 		etcdCluster.Default()
-
-		// Mock out the etcd API with one that always fails - i.e., we're always in 'bootstrap' mode
-		s.etcd = &AlwaysFailEtcdAPI{}
 
 		t.Run("AppliesAnnotationsToPod", func(t *testing.T) {
 			// Search for etcd pods using the clusterLabel
@@ -474,7 +496,8 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 	})
 
 	t.Run("PodResources", func(t *testing.T) {
-		teardownFunc, namespace := s.setupTest(t)
+		// Mock out the etcd API with one that always fails - i.e., we're always in 'bootstrap' mode
+		teardownFunc, namespace := s.setupTest(t, &AlwaysFailEtcdAPI{})
 		defer teardownFunc()
 
 		etcdCluster := test.ExampleEtcdCluster(namespace)
@@ -484,9 +507,6 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 		require.NoError(t, err, "failed to create EtcdCluster resource")
 
 		etcdCluster.Default()
-
-		// Mock out the etcd API with one that always fails - i.e., we're always in 'bootstrap' mode
-		s.etcd = &AlwaysFailEtcdAPI{}
 
 		t.Run("AppliesResourcesToPod", func(t *testing.T) {
 			replicaSetList := &appsv1.ReplicaSetList{}
@@ -501,6 +521,81 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 
 			r1 := replicaSetList.Items[0]
 			assert.Equal(t, *etcdCluster.Spec.PodTemplate.Resources, r1.Spec.Template.Spec.Containers[0].Resources)
+		})
+	})
+
+	t.Run("StatusVersion", func(t *testing.T) {
+		etcdAPI := &WrapperEtcdAPI{wrapped: &AlwaysFailEtcdAPI{}}
+
+		teardownFunc, namespace := s.setupTest(t, etcdAPI)
+		defer teardownFunc()
+
+		etcdCluster := test.ExampleEtcdCluster(namespace)
+
+		err := s.k8sClient.Create(s.ctx, etcdCluster)
+		require.NoError(t, err, "failed to create EtcdCluster resource")
+
+		etcdCluster.Default()
+
+		etcdClusterKey, err := client.ObjectKeyFromObject(etcdCluster)
+		require.NoError(t, err)
+
+		t.Run("ReportsEmptyVersion", func(t *testing.T) {
+			etcdAPI.Wrap(&AlwaysFailEtcdAPI{})
+
+			err = try.Eventually(func() error {
+				var fetchedCluster etcdv1alpha1.EtcdCluster
+				err := s.k8sClient.Get(s.ctx, etcdClusterKey, &fetchedCluster)
+				require.NoError(t, err)
+
+				defer func() {
+					err = s.triggerReconcile(&fetchedCluster)
+					require.NoError(t, err)
+				}()
+
+				const expectedVersion = ""
+				actualVersion := fetchedCluster.Status.ClusterVersion
+				if expectedVersion != actualVersion {
+					return fmt.Errorf(
+						"unexpected Status.ClusterVersion. Wanted: %s, Got: %s",
+						expectedVersion, actualVersion,
+					)
+				}
+				return nil
+			}, time.Second*5, time.Second)
+			require.NoError(t, err)
+		})
+
+		t.Run("ReportsExpectedVersion", func(t *testing.T) {
+			expectedVersion := semver.Must(semver.NewVersion("3.2.0"))
+			staticAPI := fakeEtcdForEtcdCluster(*etcdCluster)
+			staticAPI.ClusterVersion = expectedVersion.String()
+			etcdAPI.Wrap(staticAPI)
+
+			err = try.Eventually(func() error {
+				var fetchedCluster etcdv1alpha1.EtcdCluster
+				err := s.k8sClient.Get(s.ctx, etcdClusterKey, &fetchedCluster)
+				require.NoError(t, err)
+
+				defer func() {
+					err = s.triggerReconcile(&fetchedCluster)
+					require.NoError(t, err)
+				}()
+
+				if fetchedCluster.Status.ClusterVersion == "" {
+					return fmt.Errorf("Status.ClusterVersion was empty")
+				}
+				actualVersion, err := semver.NewVersion(fetchedCluster.Status.ClusterVersion)
+				require.NoError(t, err)
+				if !expectedVersion.Equal(*actualVersion) {
+					return fmt.Errorf(
+						"unexpected Status.ClusterVersion. Wanted: %s, Got: %s",
+						expectedVersion, actualVersion,
+					)
+				}
+				return nil
+			}, time.Second*5, time.Second)
+			require.NoError(t, err)
 		})
 	})
 }

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
+	etcdclient "go.etcd.io/etcd/client"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -25,13 +28,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
+	"github.com/improbable-eng/etcd-cluster-operator/internal/etcd"
 	"github.com/improbable-eng/etcd-cluster-operator/internal/etcdenvvar"
 )
 
 // EtcdPeerReconciler reconciles a EtcdPeer object
 type EtcdPeerReconciler struct {
 	client.Client
-	Log logr.Logger
+	Log  logr.Logger
+	Etcd etcd.APIBuilder
 }
 
 const (
@@ -373,15 +378,41 @@ func (o *PeerPVCDeleter) Execute(ctx context.Context) error {
 	return nil
 }
 
-func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+func (r *EtcdPeerReconciler) updateStatusVersion(ctx context.Context, log logr.Logger, peer *etcdv1alpha1.EtcdPeer) {
+	peer.Status.ServerVersion = ""
+	etcdConfig := etcdclient.Config{
+		Endpoints:               []string{advertiseURL(*peer, etcdPeerPort).String()},
+		Transport:               etcdclient.DefaultTransport,
+		HeaderTimeoutPerRequest: time.Second * 1,
+	}
+	etcdAPI, err := r.Etcd.New(etcdConfig)
+	if err != nil {
+		log.Error(err, "Failed to connect to ETCD")
+		return
+	}
+	etcdVersion, err := etcdAPI.GetVersion(ctx)
+	if err != nil {
+		log.Error(err, "Failed to get Etcd version")
+		return
+	}
+	log.Info("found version", "server", etcdVersion.Server)
+	peer.Status.ServerVersion = etcdVersion.Server
+}
+
+func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	log := r.Log.WithValues("peer", req.NamespacedName)
 
+	// Always requeue after ten seconds, as we don't watch on the membership list. So we don't auto-detect changes made
+	// to the etcd membership API.
+	// TODO(#76) Implement custom watch on etcd membership API, and remove this `requeueAfter`
+	result := ctrl.Result{RequeueAfter: time.Second * 10}
+
 	var peer etcdv1alpha1.EtcdPeer
 	if err := r.Get(ctx, req.NamespacedName, &peer); err != nil {
 		log.Error(err, "unable to fetch EtcdPeer")
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return result, client.IgnoreNotFound(err)
 	}
 
 	log.V(2).Info("Found EtcdPeer resource")
@@ -393,8 +424,26 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	err := peer.ValidateCreate()
 	if err != nil {
 		log.Error(err, "invalid EtcdPeer")
-		return ctrl.Result{}, nil
+		return result, nil
 	}
+
+	original := peer.DeepCopy()
+
+	defer func() {
+		if reflect.DeepEqual(original.Status, peer.Status) {
+			return
+		}
+		patch := client.MergeFrom(original)
+		pBytes, _ := patch.Data(&peer)
+
+		log.Info("patching status", "bytes", string(pBytes))
+		// Always attempt to patch the status after each reconciliation.
+		if err := r.Client.Status().Patch(ctx, &peer, patch); err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, fmt.Errorf("error while patching EtcdPeer.Status: %s ", err)})
+		}
+	}()
+
+	r.updateStatusVersion(ctx, log, &peer)
 
 	// Check if the peer has been marked for deletion
 	if !peer.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -412,7 +461,7 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	created, err := r.maybeCreatePvc(ctx, &peer)
 	if err != nil || created {
-		return ctrl.Result{}, err
+		return result, err
 	}
 
 	var existingReplicaSet appsv1.ReplicaSet
@@ -431,22 +480,22 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			"replica-set", replicaSet.Name)
 		if err := r.Create(ctx, &replicaSet); err != nil {
 			log.Error(err, "unable to create ReplicaSet for EtcdPeer", "replica-set", replicaSet)
-			return ctrl.Result{}, err
+			return result, err
 		}
-		return ctrl.Result{}, nil
+		return result, nil
 	}
 
 	// Check for some other error from the previous `r.Get`
 	if err != nil {
 		log.Error(err, "unable to query for replica sets")
-		return ctrl.Result{}, err
+		return result, err
 	}
 
 	log.V(2).Info("Replica set already exists", "replica-set", existingReplicaSet.Name)
 
 	// TODO Additional logic here
 
-	return ctrl.Result{}, nil
+	return result, nil
 }
 
 type pvcMapper struct{}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ replace (
 require (
 	cloud.google.com/go v0.38.0
 	github.com/coreos/etcd v3.3.17+incompatible
+	github.com/coreos/go-semver v0.3.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20190613200456-11339a705ed2
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.3.0

--- a/internal/etcd/etcd.go
+++ b/internal/etcd/etcd.go
@@ -1,22 +1,51 @@
 package etcd
 
 import (
+	"context"
+
+	"github.com/coreos/etcd/version"
 	etcdclient "go.etcd.io/etcd/client"
 )
 
-// EtcdDailer is used to connect to etcd in the first place
-type EtcdAPI interface {
-	// Give an API that provides access to etcd membership API functions.
-	MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error)
+// API contains only the ETCD APIs that we use in the operator
+// to allow for testing fakes.
+type API interface {
+	// List enumerates the current cluster membership.
+	List(ctx context.Context) ([]etcdclient.Member, error)
+
+	// Add instructs etcd to accept a new Member into the cluster.
+	Add(ctx context.Context, peerURL string) (*etcdclient.Member, error)
+
+	// Remove demotes an existing Member out of the cluster.
+	Remove(ctx context.Context, mID string) error
+
+	// GetVersion retrieves the current etcd server and cluster version
+	GetVersion(ctx context.Context) (*version.Versions, error)
 }
 
-type ClientEtcdAPI struct{}
+// APIBuilder is used to connect to etcd in the first place
+type APIBuilder interface {
+	New(etcdclient.Config) (API, error)
+}
 
-func (_ *ClientEtcdAPI) MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error) {
+type ClientEtcdAPI struct {
+	etcdclient.MembersAPI
+	etcdclient.Client
+}
+
+var _ API = &ClientEtcdAPI{}
+
+type ClientEtcdAPIBuilder struct{}
+
+var _ APIBuilder = &ClientEtcdAPIBuilder{}
+
+func (o *ClientEtcdAPIBuilder) New(config etcdclient.Config) (API, error) {
 	client, err := etcdclient.New(config)
 	if err != nil {
 		return nil, err
 	}
-
-	return etcdclient.NewMembersAPI(client), nil
+	return &ClientEtcdAPI{
+		MembersAPI: etcdclient.NewMembersAPI(client),
+		Client:     client,
+	}, nil
 }

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -27,12 +27,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/pointer"
 	kindv1alpha3 "sigs.k8s.io/kind/pkg/apis/config/v1alpha3"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cluster/create"
 	"sigs.k8s.io/kind/pkg/container/cri"
 
+	semver "github.com/coreos/go-semver/semver"
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
+	"github.com/improbable-eng/etcd-cluster-operator/internal/test"
 	"github.com/improbable-eng/etcd-cluster-operator/internal/test/try"
 )
 
@@ -414,6 +417,19 @@ func TestE2E(t *testing.T) {
 			defer cleanup()
 			backupTests(t, kubectl.WithT(t).WithDefaultNamespace(ns))
 		})
+		t.Run("Version", func(t *testing.T) {
+			t.Parallel()
+			rl := corev1.ResourceList{
+				// 1-node cluster
+				// set and get jobs
+				corev1.ResourceCPU:    resource.MustParse("300m"),
+				corev1.ResourceMemory: resource.MustParse("250Mi"),
+			}
+			kubectl := kubectl.WithT(t)
+			ns, cleanup := NamespaceForTest(t, kubectl, rl)
+			defer cleanup()
+			versionTests(t, kubectl.WithDefaultNamespace(ns))
+		})
 	})
 }
 
@@ -782,4 +798,74 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 	)
 	require.NoError(t, err, out)
 
+}
+
+func versionTests(t *testing.T, kubectl *kubectlContext) {
+	t.Log("Given a 1-node cluster.")
+	const expectedReplicas = 1
+	cluster1 := test.ExampleEtcdCluster(*kubectl.defaultNamespace)
+	cluster1.Spec.Replicas = pointer.Int32Ptr(expectedReplicas)
+	err := kubectl.ApplyObject(cluster1)
+	require.NoError(t, err)
+
+	t.Log("Containing data.")
+	expectedValue := "foobarbaz"
+
+	out, err := eventuallyInCluster(
+		kubectl,
+		"set-etcd-value",
+		time.Minute*2,
+		"quay.io/coreos/etcd:v3.2.28",
+		"etcdctl", "--insecure-discovery", "--discovery-srv=cluster1",
+		"set", "--", "foo", expectedValue,
+	)
+	require.NoError(t, err, out)
+
+	t.Log("The EtcdCluster.Status should contain the Etcd Cluster version")
+	expectedVersion := semver.Must(semver.NewVersion("3.2.0"))
+	err = try.Eventually(
+		func() error {
+			out, err := kubectl.Get("etcdcluster", "cluster1", "-o=jsonpath={.status.clusterVersion}")
+			if err != nil {
+				return err
+			}
+			actualVersion, err := semver.NewVersion(out)
+			if err != nil {
+				return fmt.Errorf("Invalid version %q: %s", out, err)
+			}
+			if !expectedVersion.Equal(*actualVersion) {
+				return fmt.Errorf(
+					"unexpected Status.ClusterVersion. Wanted: %s, Got: %s",
+					expectedVersion, actualVersion,
+				)
+			}
+			return nil
+		},
+		time.Minute*2, time.Second*10,
+	)
+	require.NoError(t, err)
+
+	t.Log("The EtcdPeer.Status should contain the Etcd server version")
+	expectedServerVersion := semver.Must(semver.NewVersion("3.2.28"))
+	err = try.Eventually(
+		func() error {
+			out, err := kubectl.Get("etcdpeer", "cluster1-0", "-o=jsonpath={.status.serverVersion}")
+			if err != nil {
+				return err
+			}
+			actualVersion, err := semver.NewVersion(out)
+			if err != nil {
+				return fmt.Errorf("Invalid version %q: %s", out, err)
+			}
+			if !expectedServerVersion.Equal(*actualVersion) {
+				return fmt.Errorf(
+					"unexpected Status.serverVersion. Wanted: %s, Got: %s",
+					expectedServerVersion, actualVersion,
+				)
+			}
+			return nil
+		},
+		time.Minute*2, time.Second*10,
+	)
+	require.NoError(t, err)
 }

--- a/internal/test/examples.go
+++ b/internal/test/examples.go
@@ -14,6 +14,10 @@ import (
 // ExampleEtcdCluster returns a valid example for testing purposes.
 func ExampleEtcdCluster(namespace string) *etcdv1alpha1.EtcdCluster {
 	return &etcdv1alpha1.EtcdCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "EtcdCluster",
+			APIVersion: "etcd.improbable.io/v1alpha1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster1",
 			Namespace: namespace,
@@ -22,10 +26,10 @@ func ExampleEtcdCluster(namespace string) *etcdv1alpha1.EtcdCluster {
 			Replicas: pointer.Int32Ptr(3),
 			Storage: &etcdv1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
-					StorageClassName: pointer.StringPtr("example-class"),
+					StorageClassName: pointer.StringPtr("standard"),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"storage": resource.MustParse("999Gi"),
+							"storage": resource.MustParse("1Mi"),
 						},
 					},
 				},
@@ -76,10 +80,10 @@ func ExampleEtcdPeer(namespace string) *etcdv1alpha1.EtcdPeer {
 			},
 			Storage: &etcdv1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
-					StorageClassName: pointer.StringPtr("example-class"),
+					StorageClassName: pointer.StringPtr("standard"),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"storage": resource.MustParse("999Gi"),
+							"storage": resource.MustParse("1Mi"),
 						},
 					},
 				},

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	if err = (&controllers.EtcdPeerReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("EtcdPeer"),
+		Etcd:   &etcd.ClientEtcdAPIBuilder{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EtcdPeer")
 		os.Exit(1)
@@ -63,7 +64,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("EtcdCluster"),
 		Recorder: mgr.GetEventRecorderFor("etcdcluster-reconciler"),
-		Etcd:     &etcd.ClientEtcdAPI{},
+		Etcd:     &etcd.ClientEtcdAPIBuilder{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EtcdCluster")
 		os.Exit(1)


### PR DESCRIPTION
Part of #98 

* Refactored the Etcd API that we use in the operator and in tests, so that I can more clearly show how it is being used in tests and to make it easier to add the GetVersion API.
* Publish the Cluster version (API version) at EtcdCluster.Status.ClusterVersion
* Publish the Server version of each peer at EtcdPeer.Status.ServerVersion