### PR TITLE
Redeploy the etcd-cluster-operator before each E2E test run

### DIFF
--- a/internal/test/e2e/kubectl.go
+++ b/internal/test/e2e/kubectl.go
@@ -261,7 +261,7 @@ func NamespaceForTest(t *testing.T, kubectl *kubectlContext, rl corev1.ResourceL
 }
 
 func DeleteAllTestNamespaces(t *testing.T, kubectl *kubectlContext) {
-	t.Log("Deleting existing namespaces")
+	t.Log("Deleting existing test namespaces")
 	err := kubectl.Delete("namespace", "--selector", testNameLabelKey, "--wait")
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This allows me to re-run `make kind CLEANUP=false`  after making changes to the operator code, 
without having to redeploy the operator manually.

I just delete the eco-system namespace each time (if it exists)

This also works around Backup test failures caused by backup files from previous test runs being found in the filesystem of the operator manager pod.

Also runs some of the setup tasks in parallel.
