### PR TITLE
Perform version upgrade by rolling update of peers

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -1,0 +1,3 @@
+package v1alpha1
+
+const etcdSupportedVersionMajor = 3

--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -72,6 +72,10 @@ type EtcdClusterStatus struct {
 	// Members contains information about each member from the etcd cluster.
 	// +optional
 	Members []EtcdMember `json:"members"`
+
+	// ClusterVersion contains the cluster API version
+	// +optional
+	ClusterVersion string `json:"clusterVersion"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -7,6 +7,10 @@ import (
 
 // EtcdClusterSpec defines the desired state of EtcdCluster
 type EtcdClusterSpec struct {
+	// Version determines the version of Etcd that will be used for this cluster.
+	// +kubebuilder:validation:Required
+	Version string `json:"version"`
+
 	// Number of instances of etcd to assemble into this cluster
 	//+kubebuilder:validation:Required
 	//+kubebuilder:validation:Minimum=1

--- a/api/v1alpha1/etcdpeer_types.go
+++ b/api/v1alpha1/etcdpeer_types.go
@@ -86,9 +86,12 @@ type EtcdPeerStorage struct {
 
 // EtcdPeerStatus defines the observed state of EtcdPeer
 type EtcdPeerStatus struct {
+	// ServerVersion contains the Member server version
+	ServerVersion string `json:"serverVersion"`
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // EtcdPeer is the Schema for the etcdpeers API
 type EtcdPeer struct {

--- a/api/v1alpha1/etcdpeer_types.go
+++ b/api/v1alpha1/etcdpeer_types.go
@@ -57,6 +57,10 @@ type EtcdPeerSpec struct {
 	// +kubebuilder:validation:MaxLength:=64
 	ClusterName string `json:"clusterName"`
 
+	// Version determines the version of Etcd that will be used for this peer.
+	// +kubebuilder:validation:Required
+	Version string `json:"version"`
+
 	// Bootstrap is the bootstrap configuration to pass down into the etcd
 	// pods. As per the etcd documentation, etcd will ignore bootstrap
 	// instructions if it already knows where it's peers are.

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -113,7 +113,12 @@ func TestEtcdCluster_ValidateUpdate(t *testing.T) {
 		{
 			name: "UnsupportedChange/ResourcesStorage",
 			modifier: func(o *v1alpha1.EtcdCluster) {
-				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = resource.MustParse("1Mi")
+				storage, found := o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"]
+				if !found {
+					panic("A storage request must be set for this test")
+				}
+				storage.Add(resource.MustParse("1Mi"))
+				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = storage
 			},
 			err: `^Unsupported changes:`,
 		},
@@ -212,7 +217,12 @@ func TestEtcdPeer_ValidateUpdate(t *testing.T) {
 		{
 			name: "UnsupportedChange/ResourcesStorage",
 			modifier: func(o *v1alpha1.EtcdPeer) {
-				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = resource.MustParse("1Mi")
+				storage, found := o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"]
+				if !found {
+					panic("A storage request must be set for this test")
+				}
+				storage.Add(resource.MustParse("1Mi"))
+				o.Spec.Storage.VolumeClaimTemplate.Resources.Requests["storage"] = storage
 			},
 			err: `^Unsupported changes:`,
 		},

--- a/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
@@ -823,8 +823,13 @@ spec:
                       type: string
                   type: object
               type: object
+            version:
+              description: Version determines the version of Etcd that will be used
+                for this cluster.
+              type: string
           required:
           - replicas
+          - version
           type: object
         status:
           description: EtcdClusterStatus defines the observed state of EtcdCluster

--- a/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdclusters.yaml
@@ -829,6 +829,9 @@ spec:
         status:
           description: EtcdClusterStatus defines the observed state of EtcdCluster
           properties:
+            clusterVersion:
+              description: ClusterVersion contains the cluster API version
+              type: string
             members:
               description: Members contains information about each member from the
                 etcd cluster.

--- a/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
@@ -871,8 +871,13 @@ spec:
                       type: string
                   type: object
               type: object
+            version:
+              description: Version determines the version of Etcd that will be used
+                for this peer.
+              type: string
           required:
           - clusterName
+          - version
           type: object
         status:
           description: EtcdPeerStatus defines the observed state of EtcdPeer

--- a/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
+++ b/config/crd/bases/etcd.improbable.io_etcdpeers.yaml
@@ -15,6 +15,8 @@ spec:
     plural: etcdpeers
     singular: etcdpeer
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: EtcdPeer is the Schema for the etcdpeers API
@@ -874,6 +876,12 @@ spec:
           type: object
         status:
           description: EtcdPeerStatus defines the observed state of EtcdPeer
+          properties:
+            serverVersion:
+              description: ServerVersion contains the Member server version
+              type: string
+          required:
+          - serverVersion
           type: object
       type: object
   version: v1alpha1

--- a/config/samples/etcd_v1alpha1_etcdcluster.yaml
+++ b/config/samples/etcd_v1alpha1_etcdcluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: my-cluster
 spec:
   replicas: 3
+  version: 3.2.28
   storage:
     volumeClaimTemplate:
       storageClassName: standard

--- a/config/samples/etcd_v1alpha1_etcdpeer.yaml
+++ b/config/samples/etcd_v1alpha1_etcdpeer.yaml
@@ -4,6 +4,7 @@ metadata:
   name: etcdpeer-sample
 spec:
   clusterName: bees
+  version: 3.2.28
   storage:
     volumeClaimTemplate:
       storageClassName: standard

--- a/config/test/e2e/backup/etcdcluster.yaml
+++ b/config/test/e2e/backup/etcdcluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: e2e-backup-cluster
 spec:
   replicas: 1
+  version: 3.2.28
   storage:
     volumeClaimTemplate:
       storageClassName: standard

--- a/config/test/e2e/defaulting/etcdcluster.yaml
+++ b/config/test/e2e/defaulting/etcdcluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: e2e-defaulting-cluster
 spec:
   replicas: 1
+  version: 3.2.28
   storage:
     volumeClaimTemplate:
       storageClassName: standard

--- a/config/test/e2e/defaulting/etcdpeer.yaml
+++ b/config/test/e2e/defaulting/etcdpeer.yaml
@@ -4,6 +4,7 @@ metadata:
   name: e2e-defaulting-peer
 spec:
   clusterName: e2e-defaulting-peer
+  version: 3.2.28
   storage:
     volumeClaimTemplate:
       resources:

--- a/config/test/e2e/persistence/cluster.yaml
+++ b/config/test/e2e/persistence/cluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cluster1
 spec:
   replicas: 1
+  version: 3.2.28
   storage:
     volumeClaimTemplate:
       storageClassName: standard

--- a/config/test/e2e/validation/etcdcluster_missing_storageclassname.yaml
+++ b/config/test/e2e/validation/etcdcluster_missing_storageclassname.yaml
@@ -5,6 +5,7 @@ kind: EtcdCluster
 metadata:
   name: e2e-defaulting-cluster
 spec:
+  version: 3.2.28
   replicas: 1
   storage:
     volumeClaimTemplate:

--- a/config/test/e2e/validation/etcdpeer_missing_storageclassname.yaml
+++ b/config/test/e2e/validation/etcdpeer_missing_storageclassname.yaml
@@ -6,6 +6,7 @@ metadata:
   name: e2e-defaulting-peer
 spec:
   clusterName: e2e-defaulting-peer
+  version: 3.2.28
   storage:
     volumeClaimTemplate:
       resources:

--- a/controllers/etcdbackupschedule_controller_test.go
+++ b/controllers/etcdbackupschedule_controller_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *controllerSuite) testBackupScheduleController(t *testing.T) {
-	teardownFunc, namespace := s.setupTest(t)
+	teardownFunc, namespace := s.setupTest(t, &AlwaysFailEtcdAPI{})
 	defer teardownFunc()
 
 	backupSchedule := test.ExampleEtcdBackupSchedule(namespace)

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -473,6 +473,9 @@ func (r *EtcdClusterReconciler) reconcile(
 	return result, nil, nil
 }
 
+// nextOutdatedPeer returns an EtcdPeer which has a different version than the
+// EtcdCluster.
+// It searches EtcdPeers in reverse name order.
 func nextOutdatedPeer(cluster *etcdv1alpha1.EtcdCluster, peers *etcdv1alpha1.EtcdPeerList) *etcdv1alpha1.EtcdPeer {
 	peerNames := make([]string, len(peers.Items))
 	peersByName := map[string]etcdv1alpha1.EtcdPeer{}

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -647,6 +647,7 @@ func peerForCluster(cluster *etcdv1alpha1.EtcdCluster, peerName string) *etcdv1a
 		},
 		Spec: etcdv1alpha1.EtcdPeerSpec{
 			ClusterName: cluster.Name,
+			Version:     cluster.Spec.Version,
 			Storage:     cluster.Spec.Storage.DeepCopy(),
 		},
 	}

--- a/controllers/etcdcluster_controller_test.go
+++ b/controllers/etcdcluster_controller_test.go
@@ -765,3 +765,13 @@ func hasIdenticalListItemNames(expected, actual metav1.ListInterface) error {
 	}
 	return nil
 }
+
+func TestPeerForCluster(t *testing.T) {
+	cluster := test.ExampleEtcdCluster("ns1")
+	peer := peerForCluster(cluster, "peer-1")
+
+	expectations := map[string]interface{}{
+		`.spec.version`: cluster.Spec.Version,
+	}
+	test.AssertStructFields(t, expectations, peer)
+}

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -40,7 +40,7 @@ type EtcdPeerReconciler struct {
 }
 
 const (
-	etcdImage           = "quay.io/coreos/etcd:v3.2.28"
+	etcdRepository      = "quay.io/coreos/etcd"
 	etcdScheme          = "http"
 	peerLabel           = "etcd.improbable.io/peer-name"
 	pvcCleanupFinalizer = "etcdpeer.etcd.improbable.io/pvc-cleanup"
@@ -138,7 +138,7 @@ func defineReplicaSet(peer etcdv1alpha1.EtcdPeer, log logr.Logger) appsv1.Replic
 
 	etcdContainer := corev1.Container{
 		Name:  appName,
-		Image: etcdImage,
+		Image: fmt.Sprintf("%s:v%s", etcdRepository, peer.Spec.Version),
 		Env: []corev1.EnvVar{
 			{
 				Name:  etcdenvvar.InitialCluster,

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
+	etcdclient "go.etcd.io/etcd/client"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -25,13 +28,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
+	"github.com/improbable-eng/etcd-cluster-operator/internal/etcd"
 	"github.com/improbable-eng/etcd-cluster-operator/internal/etcdenvvar"
 )
 
 // EtcdPeerReconciler reconciles a EtcdPeer object
 type EtcdPeerReconciler struct {
 	client.Client
-	Log logr.Logger
+	Log  logr.Logger
+	Etcd etcd.APIBuilder
 }
 
 const (
@@ -376,15 +381,41 @@ func (o *PeerPVCDeleter) Execute(ctx context.Context) error {
 	return nil
 }
 
-func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+func (r *EtcdPeerReconciler) updateStatusVersion(ctx context.Context, log logr.Logger, peer *etcdv1alpha1.EtcdPeer) {
+	peer.Status.ServerVersion = ""
+	etcdConfig := etcdclient.Config{
+		Endpoints:               []string{advertiseURL(*peer, etcdPeerPort).String()},
+		Transport:               etcdclient.DefaultTransport,
+		HeaderTimeoutPerRequest: time.Second * 1,
+	}
+	etcdAPI, err := r.Etcd.New(etcdConfig)
+	if err != nil {
+		log.Error(err, "Failed to connect to ETCD")
+		return
+	}
+	etcdVersion, err := etcdAPI.GetVersion(ctx)
+	if err != nil {
+		log.Error(err, "Failed to get Etcd version")
+		return
+	}
+	log.Info("found version", "server", etcdVersion.Server)
+	peer.Status.ServerVersion = etcdVersion.Server
+}
+
+func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	log := r.Log.WithValues("peer", req.NamespacedName)
 
+	// Always requeue after ten seconds, as we don't watch on the membership list. So we don't auto-detect changes made
+	// to the etcd membership API.
+	// TODO(#76) Implement custom watch on etcd membership API, and remove this `requeueAfter`
+	result := ctrl.Result{RequeueAfter: time.Second * 10}
+
 	var peer etcdv1alpha1.EtcdPeer
 	if err := r.Get(ctx, req.NamespacedName, &peer); err != nil {
 		log.Error(err, "unable to fetch EtcdPeer")
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return result, client.IgnoreNotFound(err)
 	}
 
 	log.V(2).Info("Found EtcdPeer resource")
@@ -396,8 +427,26 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	err := peer.ValidateCreate()
 	if err != nil {
 		log.Error(err, "invalid EtcdPeer")
-		return ctrl.Result{}, nil
+		return result, nil
 	}
+
+	original := peer.DeepCopy()
+
+	defer func() {
+		if reflect.DeepEqual(original.Status, peer.Status) {
+			return
+		}
+		patch := client.MergeFrom(original)
+		pBytes, _ := patch.Data(&peer)
+
+		log.Info("patching status", "bytes", string(pBytes))
+		// Always attempt to patch the status after each reconciliation.
+		if err := r.Client.Status().Patch(ctx, &peer, patch); err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, fmt.Errorf("error while patching EtcdPeer.Status: %s ", err)})
+		}
+	}()
+
+	r.updateStatusVersion(ctx, log, &peer)
 
 	// Check if the peer has been marked for deletion
 	if !peer.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -415,7 +464,7 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	created, err := r.maybeCreatePvc(ctx, &peer)
 	if err != nil || created {
-		return ctrl.Result{}, err
+		return result, err
 	}
 
 	var existingReplicaSet appsv1.ReplicaSet
@@ -434,22 +483,22 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			"replica-set", replicaSet.Name)
 		if err := r.Create(ctx, &replicaSet); err != nil {
 			log.Error(err, "unable to create ReplicaSet for EtcdPeer", "replica-set", replicaSet)
-			return ctrl.Result{}, err
+			return result, err
 		}
-		return ctrl.Result{}, nil
+		return result, nil
 	}
 
 	// Check for some other error from the previous `r.Get`
 	if err != nil {
 		log.Error(err, "unable to query for replica sets")
-		return ctrl.Result{}, err
+		return result, err
 	}
 
 	log.V(2).Info("Replica set already exists", "replica-set", existingReplicaSet.Name)
 
 	// TODO Additional logic here
 
-	return ctrl.Result{}, nil
+	return result, nil
 }
 
 type pvcMapper struct{}

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -427,7 +427,7 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr 
 		serverVersion string
 	)
 	etcdConfig := etcdclient.Config{
-		Endpoints:               []string{advertiseURL(peer, etcdPeerPort).String()},
+		Endpoints:               []string{advertiseURL(peer, etcdClientPort).String()},
 		Transport:               etcdclient.DefaultTransport,
 		HeaderTimeoutPerRequest: time.Second * 1,
 	}

--- a/controllers/etcdpeer_controller_test.go
+++ b/controllers/etcdpeer_controller_test.go
@@ -80,7 +80,12 @@ func (s *controllerSuite) testPeerController(t *testing.T) {
 		etcdPeer := exampleEtcdPeer(namespace)
 		const cpuLimit = "2.2"
 		const expectedGoMaxProcs = "2"
+		const expectedEtcdVersion = "9.9.9"
+		const expectedEtcdImage = "quay.io/coreos/etcd:v9.9.9"
+
+		etcdPeer.Spec.Version = expectedEtcdVersion
 		etcdPeer.Spec.PodTemplate.Resources.Limits[corev1.ResourceCPU] = resource.MustParse(cpuLimit)
+
 		err := s.k8sClient.Create(s.ctx, etcdPeer)
 		require.NoError(t, err, "failed to create EtcdPeer resource")
 
@@ -110,6 +115,7 @@ func (s *controllerSuite) testPeerController(t *testing.T) {
 			`.spec.template.spec.containers[?(@.name=="etcd")].volumeMounts[?(@.name=="etcd-data")].mountPath`: etcdDataMountPath,
 			`.spec.template.spec.containers[?(@.name=="etcd")].env[?(@.name=="ETCD_DATA_DIR")].value`:          etcdDataMountPath,
 			`.spec.template.spec.containers[?(@.name=="etcd")].env[?(@.name=="GOMAXPROCS")].value`:             expectedGoMaxProcs,
+			`.spec.template.spec.containers[?(@.name=="etcd")].image`:                                          expectedEtcdImage,
 		}
 		test.AssertStructFields(t, expectations, replicaSet)
 
@@ -422,4 +428,15 @@ func TestGoMaxProcs(t *testing.T) {
 		})
 	}
 
+}
+
+func TestDefineReplicaset(t *testing.T) {
+	logger := test.TestLogger{T: t}
+	peer := test.ExampleEtcdPeer("ns1")
+	replicaSet := defineReplicaSet(*peer, logger)
+
+	expectations := map[string]interface{}{
+		`.spec.template.spec.containers[?(@.name=="etcd")].image`: etcdRepository + ":v" + peer.Spec.Version,
+	}
+	test.AssertStructFields(t, expectations, replicaSet)
 }

--- a/controllers/etcdpeer_controller_test.go
+++ b/controllers/etcdpeer_controller_test.go
@@ -80,8 +80,8 @@ func (s *controllerSuite) testPeerController(t *testing.T) {
 		etcdPeer := exampleEtcdPeer(namespace)
 		const cpuLimit = "2.2"
 		const expectedGoMaxProcs = "2"
-		const expectedEtcdVersion = "9.9.9"
-		const expectedEtcdImage = "quay.io/coreos/etcd:v9.9.9"
+		const expectedEtcdVersion = "3.99.999"
+		const expectedEtcdImage = "quay.io/coreos/etcd:v3.99.999"
 
 		etcdPeer.Spec.Version = expectedEtcdVersion
 		etcdPeer.Spec.PodTemplate.Resources.Limits[corev1.ResourceCPU] = resource.MustParse(cpuLimit)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -26,6 +26,20 @@ replicas will degrade write performance](https://etcd.io/docs/v3.4.0/faq/#what-i
 This can be `1` for a testing environment, but for durability it is suggested that this is at least `3`. In most
 situations `5` is the highest sensible setting, although neither etcd nor this operator impose a limit.
 
+### Version
+
+The `spec.version` field determines the version of Etcd that will be used for the cluster.
+This is a required field.
+
+The version value must be a valid [Semantic Version](https://semver.org/)
+and must correspond to a tag of an [Official Etcd Docker Image](https://quay.io/repository/coreos/etcd.
+
+NOTE: Use of Docker images from other repositories is not yet supported.
+But you can load the official Docker images into a local Docker image cache if necessary.
+
+The `etcd-cluster-operator` will use the supplied `version` value to compute a Docker image name
+which is then used by the Pods for each Etcd peer.
+
 ### Storage
 
 The `spec.storage` field determines the storage options that will be used on the etcd pods. This configuration is highly

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -32,7 +32,9 @@ The `spec.version` field determines the version of Etcd that will be used for th
 This is a required field.
 
 The version value must be a valid [Semantic Version](https://semver.org/)
-and must correspond to a tag of an [Official Etcd Docker Image](https://quay.io/repository/coreos/etcd.
+and must correspond to a tag of an [Official Etcd Docker Image](https://quay.io/repository/coreos/etcd).
+
+The operator only supports Etcd major version 3.
 
 NOTE: Use of Docker images from other repositories is not yet supported.
 But you can load the official Docker images into a local Docker image cache if necessary.
@@ -320,6 +322,63 @@ $ kubectl apply -f config/samples/etcd_v1alpha1_etcdbackupschedule.yaml
 
 The resource specifies a crontab-style schedule defining how often the backup should be taken.
 It includes a spec similar to the  `EtcdBackup` resource to define how the backup should be taken, and where it should be placed.
+
+## Upgrade a Cluster
+
+To upgrade a cluster you update the `EtcdCluster`, setting a higher `.spec.version` field value.
+For example, you might upgrade the sample cluster (used in the examples above) to a newer *patch* version (from v3.2.27 to v3.2.28), by editing the
+`EtcdCluster` manifest file, as follows:
+
+```yaml
+spec:
+  version: 3.2.28
+```
+
+And then applying it:
+```bash
+$ kubectl apply -f config/samples/etcd_v1alpha1_etcdcluster.yaml
+```
+
+You can also upgrade to a higher *minor* version
+but you should first consult the [Upgrading etcd clusters and applications](https://etcd.io/docs/v3.4.0/upgrades/upgrading-etcd/) documentation
+for documentation of the upgrade from your current minor version to the new version.
+
+NOTE: You should always perform minor upgrades incrementally.
+For example, to upgrade from v3.2 to v3.4, you must first upgrade to v3.3.
+
+### Upgrade Operations
+
+When it detects a version change the `etcd-cluster-operator` will first check that the cluster is healthy.
+
+The operator will only perform upgrade operators if the Etcd cluster API is responding
+and if it reports that all Etcd members are healthy.
+
+The operator will now delete the `EtcdPeer` resources one by one and then recreate them with the new Etcd version.
+It waits for each recreated `EtcdPeer` to report its new version before deleting the next.
+It deletes and recreates the peers in reverse name order, starting with the peer that has the highest ordinal name.
+In the 3-node cluster example cluster, this will be `my-cluster-2`.
+
+As each `EtcdPeer` is deleted the associated `Pod` is also  deleted.
+NOTE: The PVC, PV and data for that `EtcdPeer` will not be deleted.
+
+When the operator recreates the `EtcdPeer`,
+a new `Pod` will be started with a newer Docker image and the new Etcd process will update the existing data (if necessary)
+and rejoin the cluster.
+
+NOTE: If "my-cluster-2" was the etcd leader, a leader election will take place and the cluster will briefly
+[Leader Failure](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/failures.md#leader-failure)
+during which the cluster will *not be able to process write requests*.
+
+Once the operator detects that all cluster members are joined and health it will delete the next EtcdPeer, and so on,
+until all the `EtcPeers` have been recreated with the newer version.
+
+You can view the version of each `EtcdPeer` by checking the value of `.status.serverVersion`.
+You can view the `EtcdCluster` version by checking the value of `.status.clusterVersion`.
+
+Once the upgrade is complete, all the `EtcdPeers` should report the new version.
+
+Additionally, the `etcd-cluster-operator` will generate an `Event` for each operation it successfully performs,
+which allows you to track the progress of the upgrade operations.
 
 ## Frequently Asked Questions
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ replace (
 require (
 	cloud.google.com/go v0.38.0
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/coreos/go-semver v0.3.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20190613200456-11339a705ed2
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect

--- a/internal/etcd/etcd.go
+++ b/internal/etcd/etcd.go
@@ -1,22 +1,51 @@
 package etcd
 
 import (
+	"context"
+
 	etcdclient "go.etcd.io/etcd/client"
+	"go.etcd.io/etcd/version"
 )
 
-// EtcdDailer is used to connect to etcd in the first place
-type EtcdAPI interface {
-	// Give an API that provides access to etcd membership API functions.
-	MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error)
+// API contains only the ETCD APIs that we use in the operator
+// to allow for testing fakes.
+type API interface {
+	// List enumerates the current cluster membership.
+	List(ctx context.Context) ([]etcdclient.Member, error)
+
+	// Add instructs etcd to accept a new Member into the cluster.
+	Add(ctx context.Context, peerURL string) (*etcdclient.Member, error)
+
+	// Remove demotes an existing Member out of the cluster.
+	Remove(ctx context.Context, mID string) error
+
+	// GetVersion retrieves the current etcd server and cluster version
+	GetVersion(ctx context.Context) (*version.Versions, error)
 }
 
-type ClientEtcdAPI struct{}
+// APIBuilder is used to connect to etcd in the first place
+type APIBuilder interface {
+	New(etcdclient.Config) (API, error)
+}
 
-func (_ *ClientEtcdAPI) MembershipAPI(config etcdclient.Config) (etcdclient.MembersAPI, error) {
+type ClientEtcdAPI struct {
+	etcdclient.MembersAPI
+	etcdclient.Client
+}
+
+var _ API = &ClientEtcdAPI{}
+
+type ClientEtcdAPIBuilder struct{}
+
+var _ APIBuilder = &ClientEtcdAPIBuilder{}
+
+func (o *ClientEtcdAPIBuilder) New(config etcdclient.Config) (API, error) {
 	client, err := etcdclient.New(config)
 	if err != nil {
 		return nil, err
 	}
-
-	return etcdclient.NewMembersAPI(client), nil
+	return &ClientEtcdAPI{
+		MembersAPI: etcdclient.NewMembersAPI(client),
+		Client:     client,
+	}, nil
 }

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -807,7 +807,7 @@ func versionTests(t *testing.T, kubectl *kubectlContext) {
 		kubectl,
 		time.Minute*2,
 		"cluster1",
-		"set", "--", "foo", expectedValue,
+		"put", "--", "foo", expectedValue,
 	)
 	require.NoError(t, err, out)
 

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -27,12 +27,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/pointer"
 	kindv1alpha3 "sigs.k8s.io/kind/pkg/apis/config/v1alpha3"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cluster/create"
 	"sigs.k8s.io/kind/pkg/container/cri"
 
+	semver "github.com/coreos/go-semver/semver"
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
+	"github.com/improbable-eng/etcd-cluster-operator/internal/test"
 	"github.com/improbable-eng/etcd-cluster-operator/internal/test/try"
 )
 
@@ -414,6 +417,19 @@ func TestE2E(t *testing.T) {
 			defer cleanup()
 			backupTests(t, kubectl.WithT(t).WithDefaultNamespace(ns))
 		})
+		t.Run("Version", func(t *testing.T) {
+			t.Parallel()
+			rl := corev1.ResourceList{
+				// 1-node cluster
+				// set and get jobs
+				corev1.ResourceCPU:    resource.MustParse("300m"),
+				corev1.ResourceMemory: resource.MustParse("250Mi"),
+			}
+			kubectl := kubectl.WithT(t)
+			ns, cleanup := NamespaceForTest(t, kubectl, rl)
+			defer cleanup()
+			versionTests(t, kubectl.WithDefaultNamespace(ns))
+		})
 	})
 }
 
@@ -770,4 +786,74 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 	)
 	require.NoError(t, err, out)
 
+}
+
+func versionTests(t *testing.T, kubectl *kubectlContext) {
+	t.Log("Given a 1-node cluster.")
+	const expectedReplicas = 1
+	cluster1 := test.ExampleEtcdCluster(*kubectl.defaultNamespace)
+	cluster1.Spec.Replicas = pointer.Int32Ptr(expectedReplicas)
+	err := kubectl.ApplyObject(cluster1)
+	require.NoError(t, err)
+
+	t.Log("Containing data.")
+	expectedValue := "foobarbaz"
+
+	out, err := eventuallyInCluster(
+		kubectl,
+		"set-etcd-value",
+		time.Minute*2,
+		"quay.io/coreos/etcd:v3.2.28",
+		"etcdctl", "--insecure-discovery", "--discovery-srv=cluster1",
+		"set", "--", "foo", expectedValue,
+	)
+	require.NoError(t, err, out)
+
+	t.Log("The EtcdCluster.Status should contain the Etcd Cluster version")
+	expectedVersion := semver.Must(semver.NewVersion("3.2.0"))
+	err = try.Eventually(
+		func() error {
+			out, err := kubectl.Get("etcdcluster", "cluster1", "-o=jsonpath={.status.clusterVersion}")
+			if err != nil {
+				return err
+			}
+			actualVersion, err := semver.NewVersion(out)
+			if err != nil {
+				return fmt.Errorf("Invalid version %q: %s", out, err)
+			}
+			if !expectedVersion.Equal(*actualVersion) {
+				return fmt.Errorf(
+					"unexpected Status.ClusterVersion. Wanted: %s, Got: %s",
+					expectedVersion, actualVersion,
+				)
+			}
+			return nil
+		},
+		time.Minute*2, time.Second*10,
+	)
+	require.NoError(t, err)
+
+	t.Log("The EtcdPeer.Status should contain the Etcd server version")
+	expectedServerVersion := semver.Must(semver.NewVersion("3.2.28"))
+	err = try.Eventually(
+		func() error {
+			out, err := kubectl.Get("etcdpeer", "cluster1-0", "-o=jsonpath={.status.serverVersion}")
+			if err != nil {
+				return err
+			}
+			actualVersion, err := semver.NewVersion(out)
+			if err != nil {
+				return fmt.Errorf("Invalid version %q: %s", out, err)
+			}
+			if !expectedServerVersion.Equal(*actualVersion) {
+				return fmt.Errorf(
+					"unexpected Status.serverVersion. Wanted: %s, Got: %s",
+					expectedServerVersion, actualVersion,
+				)
+			}
+			return nil
+		},
+		time.Minute*2, time.Second*10,
+	)
+	require.NoError(t, err)
 }

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -803,12 +803,10 @@ func versionTests(t *testing.T, kubectl *kubectlContext) {
 	t.Log("Containing data.")
 	expectedValue := "foobarbaz"
 
-	out, err := eventuallyInCluster(
+	out, err := etcdctlInCluster(
 		kubectl,
-		"set-etcd-value",
 		time.Minute*2,
-		"quay.io/coreos/etcd:v3.2.28",
-		"etcdctl", "--insecure-discovery", "--discovery-srv=cluster1",
+		"cluster1",
 		"set", "--", "foo", expectedValue,
 	)
 	require.NoError(t, err, out)

--- a/internal/test/examples.go
+++ b/internal/test/examples.go
@@ -24,7 +24,7 @@ func ExampleEtcdCluster(namespace string) *etcdv1alpha1.EtcdCluster {
 		},
 		Spec: etcdv1alpha1.EtcdClusterSpec{
 			Replicas: pointer.Int32Ptr(3),
-			Version:  "0.0.0",
+			Version:  "3.4.5",
 			Storage: &etcdv1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
 					StorageClassName: pointer.StringPtr("standard"),
@@ -60,7 +60,7 @@ func ExampleEtcdPeer(namespace string) *etcdv1alpha1.EtcdPeer {
 		},
 		Spec: etcdv1alpha1.EtcdPeerSpec{
 			ClusterName: "my-cluster",
-			Version:     "1.1.1",
+			Version:     "3.4.5",
 			Bootstrap: &etcdv1alpha1.Bootstrap{
 				Static: &etcdv1alpha1.StaticBootstrap{
 					InitialCluster: []etcdv1alpha1.InitialClusterMember{

--- a/internal/test/examples.go
+++ b/internal/test/examples.go
@@ -24,6 +24,7 @@ func ExampleEtcdCluster(namespace string) *etcdv1alpha1.EtcdCluster {
 		},
 		Spec: etcdv1alpha1.EtcdClusterSpec{
 			Replicas: pointer.Int32Ptr(3),
+			Version:  "0.0.0",
 			Storage: &etcdv1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
 					StorageClassName: pointer.StringPtr("standard"),
@@ -59,6 +60,7 @@ func ExampleEtcdPeer(namespace string) *etcdv1alpha1.EtcdPeer {
 		},
 		Spec: etcdv1alpha1.EtcdPeerSpec{
 			ClusterName: "my-cluster",
+			Version:     "1.1.1",
 			Bootstrap: &etcdv1alpha1.Bootstrap{
 				Static: &etcdv1alpha1.StaticBootstrap{
 					InitialCluster: []etcdv1alpha1.InitialClusterMember{

--- a/internal/test/examples.go
+++ b/internal/test/examples.go
@@ -24,7 +24,7 @@ func ExampleEtcdCluster(namespace string) *etcdv1alpha1.EtcdCluster {
 		},
 		Spec: etcdv1alpha1.EtcdClusterSpec{
 			Replicas: pointer.Int32Ptr(3),
-			Version:  "3.4.5",
+			Version:  "3.4.999",
 			Storage: &etcdv1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
 					StorageClassName: pointer.StringPtr("standard"),
@@ -60,7 +60,7 @@ func ExampleEtcdPeer(namespace string) *etcdv1alpha1.EtcdPeer {
 		},
 		Spec: etcdv1alpha1.EtcdPeerSpec{
 			ClusterName: "my-cluster",
-			Version:     "3.4.5",
+			Version:     "3.4.999",
 			Bootstrap: &etcdv1alpha1.Bootstrap{
 				Static: &etcdv1alpha1.StaticBootstrap{
 					InitialCluster: []etcdv1alpha1.InitialClusterMember{

--- a/internal/test/examples.go
+++ b/internal/test/examples.go
@@ -14,6 +14,10 @@ import (
 // ExampleEtcdCluster returns a valid example for testing purposes.
 func ExampleEtcdCluster(namespace string) *etcdv1alpha1.EtcdCluster {
 	return &etcdv1alpha1.EtcdCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "EtcdCluster",
+			APIVersion: "etcd.improbable.io/v1alpha1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster1",
 			Namespace: namespace,
@@ -22,10 +26,10 @@ func ExampleEtcdCluster(namespace string) *etcdv1alpha1.EtcdCluster {
 			Replicas: pointer.Int32Ptr(3),
 			Storage: &etcdv1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
-					StorageClassName: pointer.StringPtr("example-class"),
+					StorageClassName: pointer.StringPtr("standard"),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"storage": resource.MustParse("999Gi"),
+							"storage": resource.MustParse("1Mi"),
 						},
 					},
 				},
@@ -76,10 +80,10 @@ func ExampleEtcdPeer(namespace string) *etcdv1alpha1.EtcdPeer {
 			},
 			Storage: &etcdv1alpha1.EtcdPeerStorage{
 				VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
-					StorageClassName: pointer.StringPtr("example-class"),
+					StorageClassName: pointer.StringPtr("standard"),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"storage": resource.MustParse("999Gi"),
+							"storage": resource.MustParse("1Mi"),
 						},
 					},
 				},

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	if err = (&controllers.EtcdPeerReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("EtcdPeer"),
+		Etcd:   &etcd.ClientEtcdAPIBuilder{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EtcdPeer")
 		os.Exit(1)
@@ -63,7 +64,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("EtcdCluster"),
 		Recorder: mgr.GetEventRecorderFor("etcdcluster-reconciler"),
-		Etcd:     &etcd.ClientEtcdAPI{},
+		Etcd:     &etcd.ClientEtcdAPIBuilder{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EtcdCluster")
 		os.Exit(1)


### PR DESCRIPTION
Fixes: #98 

* Adds spec.version to allow the version to be configured
* Adds status.version fields to publish the version discovered from the etcd API
* Updates peers one at a time by removing a peer and waiting for a new peer to be created with the expected version.
* Refactored our internal Etcd API interface to make it less membership focused and to make it easier to update the fake etcd during tests.
* Variious refactoring of the status updates for cluster and peer controllers to ensure that status gets updated on each reconcile.