### PR TITLE
Use ETCDCTL_API=3 in e2e tests

### DIFF
--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -427,7 +427,7 @@ func backupTests(t *testing.T, kubectl *kubectlContext) {
 		kubectl,
 		time.Minute*2,
 		"e2e-backup-cluster",
-		"set", "--", "foo", "bar",
+		"put", "--", "foo", "bar",
 	)
 	require.NoError(t, err, out)
 
@@ -628,7 +628,7 @@ func persistenceTests(t *testing.T, kubectl *kubectlContext) {
 		kubectl,
 		time.Minute*2,
 		"cluster1",
-		"set", "--", "foo", expectedValue,
+		"put", "--", "foo", expectedValue,
 	)
 	require.NoError(t, err, out)
 
@@ -662,7 +662,7 @@ func persistenceTests(t *testing.T, kubectl *kubectlContext) {
 		kubectl,
 		time.Minute*2,
 		"cluster1",
-		"get", "--quorum", "--", "foo",
+		"get", "--print-value-only", "--", "foo",
 	)
 	require.NoError(t, err, out)
 	assert.Equal(t, expectedValue+"\n", out)
@@ -701,7 +701,7 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 		kubectl,
 		time.Minute*2,
 		"my-cluster",
-		"set", "--", "foo", expectedValue,
+		"put", "--", "foo", expectedValue,
 	)
 	require.NoError(t, err, out)
 
@@ -732,7 +732,7 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 		kubectl,
 		time.Minute*2,
 		"my-cluster",
-		"get", "--quorum", "--", "foo",
+		"get", "--print-value-only", "--", "foo",
 	)
 	require.NoError(t, err, out)
 	assert.Equal(t, expectedValue+"\n", out)
@@ -766,7 +766,7 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 		kubectl,
 		time.Minute*2,
 		"my-cluster",
-		"set", "--", "foo2", expectedValue+"2",
+		"put", "--", "foo2", expectedValue+"2",
 	)
 	require.NoError(t, err, out)
 

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -423,12 +423,10 @@ func backupTests(t *testing.T, kubectl *kubectlContext) {
 	require.NoError(t, err)
 
 	t.Log("Containing data.")
-	out, err := eventuallyInCluster(
+	out, err := etcdctlInCluster(
 		kubectl,
-		"set-etcd-value",
 		time.Minute*2,
-		"quay.io/coreos/etcd:v3.2.27",
-		"etcdctl", "--insecure-discovery", "--discovery-srv=e2e-backup-cluster",
+		"e2e-backup-cluster",
 		"set", "--", "foo", "bar",
 	)
 	require.NoError(t, err, out)
@@ -626,12 +624,10 @@ func persistenceTests(t *testing.T, kubectl *kubectlContext) {
 	t.Log("Containing data.")
 	expectedValue := "foobarbaz"
 
-	out, err := eventuallyInCluster(
+	out, err := etcdctlInCluster(
 		kubectl,
-		"set-etcd-value",
 		time.Minute*2,
-		"quay.io/coreos/etcd:v3.2.27",
-		"etcdctl", "--insecure-discovery", "--discovery-srv=cluster1",
+		"cluster1",
 		"set", "--", "foo", expectedValue,
 	)
 	require.NoError(t, err, out)
@@ -662,12 +658,10 @@ func persistenceTests(t *testing.T, kubectl *kubectlContext) {
 	require.NoError(t, err)
 
 	t.Log("And the data is still available.")
-	out, err = eventuallyInCluster(
+	out, err = etcdctlInCluster(
 		kubectl,
-		"get-etcd-value",
 		time.Minute*2,
-		"quay.io/coreos/etcd:v3.2.27",
-		"etcdctl", "--insecure-discovery", "--discovery-srv=cluster1",
+		"cluster1",
 		"get", "--quorum", "--", "foo",
 	)
 	require.NoError(t, err, out)
@@ -703,12 +697,10 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 	t.Log("Which contains data")
 	const expectedValue = "foobarbaz"
 
-	out, err := eventuallyInCluster(
+	out, err := etcdctlInCluster(
 		kubectl,
-		"set-etcd-value",
 		time.Minute*2,
-		"quay.io/coreos/etcd:v3.2.27",
-		"etcdctl", "--insecure-discovery", "--discovery-srv=my-cluster",
+		"my-cluster",
 		"set", "--", "foo", expectedValue,
 	)
 	require.NoError(t, err, out)
@@ -736,12 +728,10 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 	require.NoError(t, err)
 
 	t.Log("And the data is still available.")
-	out, err = eventuallyInCluster(
+	out, err = etcdctlInCluster(
 		kubectl,
-		"get-etcd-value",
 		time.Minute*2,
-		"quay.io/coreos/etcd:v3.2.27",
-		"etcdctl", "--insecure-discovery", "--discovery-srv=my-cluster",
+		"my-cluster",
 		"get", "--quorum", "--", "foo",
 	)
 	require.NoError(t, err, out)
@@ -772,12 +762,10 @@ func scaleDownTests(t *testing.T, kubectl *kubectlContext) {
 	require.NoError(t, err)
 
 	t.Log("And new data can be written to the cluster")
-	out, err = eventuallyInCluster(
+	out, err = etcdctlInCluster(
 		kubectl,
-		"set-etcd-value2",
 		time.Minute*2,
-		"quay.io/coreos/etcd:v3.2.27",
-		"etcdctl", "--insecure-discovery", "--discovery-srv=my-cluster",
+		"my-cluster",
 		"set", "--", "foo2", expectedValue+"2",
 	)
 	require.NoError(t, err, out)

--- a/internal/test/e2e/kubectl.go
+++ b/internal/test/e2e/kubectl.go
@@ -25,7 +25,9 @@ const (
 	testNameLabelKey = "e2e.etcd.improbable.io/test-name"
 	// The etcd image containing etcdctl
 	etcdctlImage = "quay.io/coreos/etcd:v3.3.18"
-	// charSet defines the alphanumeric set for random string generation
+	// charSet defines the alphanumeric set for random string generation.
+	// These must encode to a single byte in UTF-8 for compatibility with the
+	// randomString() function.
 	charSet = "0123456789abcdefghijklmnopqrstuvwxyz"
 )
 

--- a/internal/test/e2e/kubectl.go
+++ b/internal/test/e2e/kubectl.go
@@ -24,7 +24,7 @@ import (
 const (
 	testNameLabelKey = "e2e.etcd.improbable.io/test-name"
 	// The etcd image containing etcdctl
-	etcdctlImage = "quay.io/coreos/etcd:v3.2.28"
+	etcdctlImage = "quay.io/coreos/etcd:v3.3.18"
 	// charSet defines the alphanumeric set for random string generation
 	charSet = "0123456789abcdefghijklmnopqrstuvwxyz"
 )
@@ -354,6 +354,6 @@ func etcdctlInCluster(kubectl *kubectlContext, deadline time.Duration, clusterNa
 		"etcdctl-"+randomString(8),
 		deadline,
 		etcdctlImage,
-		append([]string{"etcdctl", "--insecure-discovery", "--discovery-srv", clusterName}, command...)...,
+		append([]string{"/usr/bin/env", "ETCDCTL_API=3", "etcdctl", "--insecure-discovery", "--discovery-srv", clusterName}, command...)...,
 	)
 }


### PR DESCRIPTION
* Use ETCDCTL_API=3 in our E2E tests.
* Add a wrapper function to make it easier to execute etcdctl in tests