### PR TITLE
Stub backup-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,11 @@ docker-build:
 docker-build-debug:
 	docker build . --target debug --build-arg VERSION=$(VERSION) -t ${IMG}
 
-# Build the docker image. This should be used for release versions, and builds the image on top of distroless.
+docker-build-proxy:
+	docker build --build-arg VERSION=$(VERSION) --tag "eco-proxy:$(VERSION)" --file build/package/proxy.Dockerfile .
+
 docker-build-backup-agent:
-	docker build . --target backup-agent --build-arg VERSION=$(VERSION) -t "eco-backup-agent:$(VERSION)"
+	docker build --build-arg VERSION=$(VERSION) --tag "eco-backup-agent:$(VERSION)" --file build/package/backup-agent.Dockerfile .
 
 # Push the docker image
 docker-push:

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ docker-build:
 docker-build-debug:
 	docker build . --target debug --build-arg VERSION=$(VERSION) -t ${IMG}
 
+# Build the docker image. This should be used for release versions, and builds the image on top of distroless.
+docker-build-backup-agent:
+	docker build . --target backup-agent --build-arg VERSION=$(VERSION) -t "eco-backup-agent:$(VERSION)"
+
 # Push the docker image
 docker-push:
 	docker push ${IMG}

--- a/build/package/proxy.Dockerfile
+++ b/build/package/proxy.Dockerfile
@@ -13,9 +13,18 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
+COPY version/ version/
+
+ARG VERSION
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
+ENV GO111MODULE=on
+ENV GOFLAGS=-ldflags=-X=github.com/improbable-eng/etcd-cluster-operator/version.Version=${VERSION}
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o proxy cmd/proxy/main.go
+RUN go build -o proxy cmd/proxy/main.go
 
 FROM gcr.io/distroless/static:nonroot as release
 WORKDIR /

--- a/cmd/backup-agent/main.go
+++ b/cmd/backup-agent/main.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
-	"github.com/improbable-eng/etcd-cluster-operator/controllers"
 	"github.com/improbable-eng/etcd-cluster-operator/version"
 )
 
@@ -22,14 +21,12 @@ var (
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
-
 	_ = etcdv1alpha1.AddToScheme(scheme)
-	// +kubebuilder:scaffold:scheme
 }
 
 func main() {
 	printVersion := flag.Bool("version", false, "Print the version to stdout and exit")
-	backupTmpDir := flag.String("backup-tmp-dir", os.TempDir(), "The directory to temporarily place backups before they are uploaded to their destination.")
+
 	flag.Parse()
 
 	if *printVersion {
@@ -44,15 +41,6 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
-	if err = (&controllers.EtcdBackupReconciler{
-		Client:  mgr.GetClient(),
-		Log:     ctrl.Log.WithName("controllers").WithName("EtcdBackup"),
-		TempDir: *backupTmpDir,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "EtcdBackup")
 		os.Exit(1)
 	}
 

--- a/cmd/backup-agent/main.go
+++ b/cmd/backup-agent/main.go
@@ -28,16 +28,11 @@ func init() {
 }
 
 func main() {
-	var (
-		printVersion  bool
-		backupTempDir string
-	)
-
-	flag.BoolVar(&printVersion, "version", false, "Print the version to stdout and exit")
-	flag.StringVar(&backupTempDir, "backup-tmp-dir", os.TempDir(), "The directory to temporarily place backups before they are uploaded to their destination.")
+	printVersion := flag.Bool("version", false, "Print the version to stdout and exit")
+	backupTmpDir := flag.String("backup-tmp-dir", os.TempDir(), "The directory to temporarily place backups before they are uploaded to their destination.")
 	flag.Parse()
 
-	if printVersion {
+	if *printVersion {
 		fmt.Println(version.Version)
 		os.Exit(0)
 	}
@@ -55,7 +50,7 @@ func main() {
 	if err = (&controllers.EtcdBackupReconciler{
 		Client:  mgr.GetClient(),
 		Log:     ctrl.Log.WithName("controllers").WithName("EtcdBackup"),
-		TempDir: backupTempDir,
+		TempDir: *backupTmpDir,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EtcdBackup")
 		os.Exit(1)

--- a/cmd/backup-agent/main.go
+++ b/cmd/backup-agent/main.go
@@ -2,17 +2,29 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	flag "github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	etcdv1alpha1 "github.com/improbable-eng/etcd-cluster-operator/api/v1alpha1"
 	"github.com/improbable-eng/etcd-cluster-operator/version"
 )
 
 var (
+	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
+
+func init() {
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	_ = etcdv1alpha1.AddToScheme(scheme)
+	// +kubebuilder:scaffold:scheme
+}
 
 func main() {
 	var printVersion bool
@@ -22,9 +34,21 @@ func main() {
 
 	if printVersion {
 		fmt.Println(version.Version)
-		return
+		os.Exit(0)
 	}
 	ctrl.SetLogger(zap.Logger(true))
 
 	setupLog.Info("Starting backup-agent", "version", version.Version)
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
 }

--- a/cmd/backup-agent/main.go
+++ b/cmd/backup-agent/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+
+	flag "github.com/spf13/pflag"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/improbable-eng/etcd-cluster-operator/version"
+)
+
+var (
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func main() {
+	var printVersion bool
+
+	flag.BoolVar(&printVersion, "version", false, "Print the version to stdout and exit")
+	flag.Parse()
+
+	if printVersion {
+		fmt.Println(version.Version)
+		return
+	}
+	ctrl.SetLogger(zap.Logger(true))
+
+	setupLog.Info("Starting backup-agent", "version", version.Version)
+}


### PR DESCRIPTION
* A go binary that reports its version
* Docker image
* Make target

Also edited the stub proxy a bit to log and optionally print its version  and use the controller-runtime + zap logging framework, consistent with the existing controller binary.