### PR TITLE
Reduce the size of Go binaries by stripping and compressing

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,8 +25,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 100Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
* Strip the debugging information (-s -w)
* Compress the binary using upx
* Added more memory to the operator pod so that it has room to self-extract

See: https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/

It does slow down the build by a few seconds, but it reduces the sizes quite significantly which helps when doing regular docker-push to GCR.

Not sure it's worth it, but it's been an interesting experiment.

* Original
```
docker images
REPOSITORY                                                       TAG                  IMAGE ID            CREATED             SIZE
gcr.io/jetstack-richard/etcd-cluster-operator-backup-agent       v0.2.0-8-g1c6a509    d5ea0f5d30d4        16 hours ago        44.1MB
gcr.io/jetstack-richard/etcd-cluster-operator-proxy              v0.2.0-8-g1c6a509    7007de2e913f        16 hours ago        41.9MB
gcr.io/jetstack-richard/etcd-cluster-operator-controller-debug   v0.2.0-8-g1c6a509    0c7722c7de4d        16 hours ago        66.6MB
gcr.io/jetstack-richard/etcd-cluster-operator-controller         v0.2.0-8-g1c6a509    b664775d6d2a        16 hours ago        54.5MB
```
* -ldflags=-s -w"
```
docker images
REPOSITORY                                                       TAG                  IMAGE ID            CREATED             SIZE
quay.io/improbable-eng/etcd-cluster-operator-backup-agent        v0.2.0-8-g1c6a509    4dc9c218979d        5 seconds ago       32.9MB
quay.io/improbable-eng/etcd-cluster-operator-proxy               v0.2.0-8-g1c6a509    d87ffff4789f        9 seconds ago       31.3MB
quay.io/improbable-eng/etcd-cluster-operator-controller-debug    v0.2.0-8-g1c6a509    0536168ed506        14 seconds ago      52.6MB
quay.io/improbable-eng/etcd-cluster-operator-controller          v0.2.0-8-g1c6a509    dc8cd289a634        23 seconds ago      40.5MB
```
* upx
```
docker images
REPOSITORY                                                       TAG                  IMAGE ID            CREATED             SIZE
quay.io/improbable-eng/etcd-cluster-operator-backup-agent        v0.2.0-8-g1c6a509    3699f1bb8b21        4 seconds ago       10.9MB
quay.io/improbable-eng/etcd-cluster-operator-proxy               v0.2.0-8-g1c6a509    cb00b8727052        8 seconds ago       10.5MB
quay.io/improbable-eng/etcd-cluster-operator-controller-debug    v0.2.0-8-g1c6a509    606eccae02fe        13 seconds ago      25.5MB
quay.io/improbable-eng/etcd-cluster-operator-controller          v0.2.0-8-g1c6a509    81884510a8a7        21 seconds ago      13.4MB
```
Stacked on: #164