### PR TITLE
Use newer Circle CI machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   verify:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-1604:201903-01
     steps:
       - run:
           name: Install Go
@@ -30,7 +30,7 @@ jobs:
          command: make test
   e2e:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-1604:201903-01
     working_directory: ~/go/src/github.com/improbable-eng/etcd-cluster-operator
     steps:
       - run:


### PR DESCRIPTION
This is now the recommended machine image:
* https://circleci.com/docs/2.0/executor-types/#using-machine

Classic remains the default for backwards compatibility reasons
* https://discuss.circleci.com/t/default-machine-executor-image-update/29308