### PR TITLE
Add a host alias so that Etcd node can resolve its own address

### DIFF
--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -656,7 +656,7 @@ func etcdClientConfig(cluster *etcdv1alpha1.EtcdCluster) etcdclient.Config {
 		Scheme: etcdScheme,
 		// We (the operator) are quite probably in a different namespace to the cluster, so we need to use a fully
 		// defined URL.
-		Host: fmt.Sprintf("%s.%s.svc:%d", cluster.Name, cluster.Namespace, etcdClientPort),
+		Host: fmt.Sprintf("%s.%s:%d", cluster.Name, cluster.Namespace, etcdClientPort),
 	}
 	return etcdclient.Config{
 		Endpoints:               []string{serviceURL.String()},
@@ -776,10 +776,9 @@ func expectedPeerNamesForCluster(cluster *etcdv1alpha1.EtcdCluster) (names []str
 // namespace. This does not include a port or scheme, so can be used as either a "peer" URL using the peer port or the
 // client URL using the client port.
 func expectedURLForPeer(cluster *etcdv1alpha1.EtcdCluster, peerName string) string {
-	return fmt.Sprintf("%s.%s.%s.svc",
+	return fmt.Sprintf("%s.%s",
 		peerName,
 		cluster.Name,
-		cluster.Namespace,
 	)
 }
 

--- a/controllers/etcdcluster_controller_test.go
+++ b/controllers/etcdcluster_controller_test.go
@@ -354,10 +354,7 @@ func (s *controllerSuite) testClusterController(t *testing.T) {
 			for i, peer := range peers.Items {
 				expectedInitialCluster[i] = etcdv1alpha1.InitialClusterMember{
 					Name: peer.Name,
-					Host: fmt.Sprintf("%s.%s.%s.svc",
-						peer.Name,
-						etcdCluster.Name,
-						namespace),
+					Host: fmt.Sprintf("%s.%s", peer.Name, etcdCluster.Name),
 				}
 			}
 

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -434,7 +434,9 @@ func (r *EtcdPeerReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr 
 		serverVersion string
 	)
 	etcdConfig := etcdclient.Config{
-		Endpoints:               []string{advertiseURL(peer, etcdClientPort).String()},
+		Endpoints: []string{
+			fmt.Sprintf("%s://%s.%s.%s:%d", etcdScheme, peer.Name, peer.Spec.ClusterName, peer.Namespace, etcdClientPort),
+		},
 		Transport:               etcdclient.DefaultTransport,
 		HeaderTimeoutPerRequest: time.Second * 1,
 	}

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -77,10 +77,9 @@ func advertiseURL(etcdPeer etcdv1alpha1.EtcdPeer, port int32) *url.URL {
 	return &url.URL{
 		Scheme: etcdScheme,
 		Host: fmt.Sprintf(
-			"%s.%s.%s.svc:%d",
+			"%s.%s:%d",
 			etcdPeer.Name,
 			etcdPeer.Spec.ClusterName,
-			etcdPeer.Namespace,
 			port,
 		),
 	}

--- a/controllers/etcdpeer_controller.go
+++ b/controllers/etcdpeer_controller.go
@@ -227,8 +227,16 @@ func defineReplicaSet(peer etcdv1alpha1.EtcdPeer, log logr.Logger) appsv1.Replic
 					Namespace:   peer.Namespace,
 				},
 				Spec: corev1.PodSpec{
-					Hostname:   peer.Name,
-					Subdomain:  peer.Spec.ClusterName,
+					Hostname:  peer.Name,
+					Subdomain: peer.Spec.ClusterName,
+					HostAliases: []corev1.HostAlias{
+						{
+							IP: "127.0.0.1",
+							Hostnames: []string{
+								fmt.Sprintf("%s.%s", peer.Name, peer.Spec.ClusterName),
+							},
+						},
+					},
 					Containers: []corev1.Container{etcdContainer},
 					Volumes: []corev1.Volume{
 						{

--- a/controllers/etcdpeer_controller_test.go
+++ b/controllers/etcdpeer_controller_test.go
@@ -134,9 +134,9 @@ func (s *controllerSuite) testPeerController(t *testing.T) {
 
 		peers := strings.Split(requireEnvVar(t, etcdContainer.Env, "ETCD_INITIAL_CLUSTER"), ",")
 		require.Len(t, peers, 3)
-		require.Contains(t, peers, fmt.Sprintf("bees=http://bees.my-cluster.%s.svc:2380", namespace))
-		require.Contains(t, peers, fmt.Sprintf("goose=http://goose.my-cluster.%s.svc:2380", namespace))
-		require.Contains(t, peers, fmt.Sprintf("magic=http://magic.my-cluster.%s.svc:2380", namespace))
+		require.Contains(t, peers, "bees=http://bees.my-cluster:2380")
+		require.Contains(t, peers, "goose=http://goose.my-cluster:2380")
+		require.Contains(t, peers, "magic=http://magic.my-cluster:2380")
 
 		require.Equal(t,
 			etcdPeer.Name,
@@ -145,19 +145,13 @@ func (s *controllerSuite) testPeerController(t *testing.T) {
 		)
 
 		require.Equal(t,
-			fmt.Sprintf("http://%s.%s.%s.svc:2380",
-				etcdPeer.Name,
-				etcdPeer.Spec.ClusterName,
-				etcdPeer.Namespace),
+			fmt.Sprintf("http://%s.%s:2380", etcdPeer.Name, etcdPeer.Spec.ClusterName),
 			requireEnvVar(t, etcdContainer.Env, "ETCD_INITIAL_ADVERTISE_PEER_URLS"),
 			"ETCD_INITIAL_ADVERTISE_PEER_URLS environment variable set incorrectly",
 		)
 
 		require.Equal(t,
-			fmt.Sprintf("http://%s.%s.%s.svc:2379",
-				etcdPeer.Name,
-				etcdPeer.Spec.ClusterName,
-				etcdPeer.Namespace),
+			fmt.Sprintf("http://%s.%s:2379", etcdPeer.Name, etcdPeer.Spec.ClusterName),
 			requireEnvVar(t, etcdContainer.Env, "ETCD_ADVERTISE_CLIENT_URLS"),
 			"ETCD_ADVERTISE_CLIENT_URLS environment variable set incorrectly",
 		)

--- a/internal/test/examples.go
+++ b/internal/test/examples.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,15 +64,15 @@ func ExampleEtcdPeer(namespace string) *etcdv1alpha1.EtcdPeer {
 					InitialCluster: []etcdv1alpha1.InitialClusterMember{
 						{
 							Name: "bees",
-							Host: fmt.Sprintf("bees.my-cluster.%s.svc", namespace),
+							Host: "bees.my-cluster",
 						},
 						{
 							Name: "magic",
-							Host: fmt.Sprintf("magic.my-cluster.%s.svc", namespace),
+							Host: "magic.my-cluster",
 						},
 						{
 							Name: "goose",
-							Host: fmt.Sprintf("goose.my-cluster.%s.svc", namespace),
+							Host: "goose.my-cluster",
 						},
 					},
 				},


### PR DESCRIPTION
Without waiting for headless service.
Also simplified the peer domain names
Removed the `.svc` part which should require fewer failed ndot lookups

Fixes: https://github.com/improbable-eng/etcd-cluster-operator/issues/92