### PR TITLE
Add a new `make release` rule for automating parts of the release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ deploy-cert-manager: ## Deploy cert-manager in the configured Kubernetes cluster
 
 .PHONY: deploy-controller
 deploy-controller: ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+deploy-controller: kustomize-edit-set-image
 	${KUSTOMIZE} build ${KUSTOMIZE_DIRECTORY_TO_DEPLOY} | kubectl apply -f -
 	kubectl --namespace eco-system wait --for=condition=Available --timeout=60s deploy eco-controller-manager
 	kubectl --namespace eco-system wait --for=condition=Available --timeout=60s deploy eco-proxy

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -203,10 +203,16 @@ string will be prefixed with `v` and use semver.
 * Sanity check documentation under `docs` and `README.md`.
 * Compile and prepare release notes under `docs/release-notes/$VERSION.md`. For example versions v0.1.X would share a
 file `docs/release-notes/v0.1.md`.
+* Some of the release steps have been automated. Run `make --dry-run release VERSION=0.0.0` to see the steps that will be automatically performed.
 
 ### Process
 
-1. Tag the repository with the new version, e.g., `git tag v0.1.0` and push the tag to GitHub.
-2. Mark the tag as a release on GitHub.
-3. Build a Docker Image from the repository at that tag and push it to Docker Hub.
-4. Build a version of the deployment YAML with the image tag, attach it to the GitHub release as a YAML file.
+1. Run `make release VERSION=0.1.0`. This will:
+   1. Build Docker images with the supplied VERSION.
+   2. Push Docker images to the repo defined in DOCKER_REPO.
+   3. Create a `release-$VERSION.yaml` containing an example deployment for this version.
+   4. Create an annotated Git tag for the supplied VERSION.
+2. Push the tag to GitHub.
+3. Mark the tag as a release on GitHub.
+4. Build a Docker Image from the repository at that tag and push it to Docker Hub.
+5. Build a version of the deployment YAML with the image tag, attach it to the GitHub release as a YAML file.


### PR DESCRIPTION
You can try this out locally by running:

```
make --dry-run release DOCKER_REPO=gcr.io/<YOUR_PROJECT> VERSION=v0.3.0-rc.1
make release DOCKER_REPO=gcr.io/<YOUR_PROJECT> VERSION=v0.3.0-rc.1
```