### PR TITLE
Allow etcd repository to be overridden

### DIFF
--- a/controllers/etcdpeer_controller_test.go
+++ b/controllers/etcdpeer_controller_test.go
@@ -427,7 +427,8 @@ func TestGoMaxProcs(t *testing.T) {
 func TestDefineReplicaset(t *testing.T) {
 	logger := test.TestLogger{T: t}
 	peer := test.ExampleEtcdPeer("ns1")
-	replicaSet := defineReplicaSet(*peer, logger)
+	etcdRepository := "quay.io/coreos/etcd"
+	replicaSet := defineReplicaSet(*peer, etcdRepository, logger)
 
 	expectations := map[string]interface{}{
 		`.spec.template.spec.containers[?(@.name=="etcd")].image`: etcdRepository + ":v" + peer.Spec.Version,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -93,9 +93,10 @@ func (s *controllerSuite) setupTest(t *testing.T, etcdAPI etcd.APIBuilder) (tear
 	require.NoError(t, err, "failed to create manager")
 
 	peerController := EtcdPeerReconciler{
-		Client: mgr.GetClient(),
-		Log:    logger.WithName("EtcdPeer"),
-		Etcd:   etcdAPI,
+		Client:         mgr.GetClient(),
+		Log:            logger.WithName("EtcdPeer"),
+		Etcd:           etcdAPI,
+		EtcdRepository: "quay.io/coreos/etcd",
 	}
 	err = peerController.SetupWithManager(mgr)
 	require.NoError(t, err, "failed to set up EtcdPeer controller")

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -36,8 +36,8 @@ and must correspond to a tag of an [Official Etcd Docker Image](https://quay.io/
 
 The operator only supports Etcd major version 3.
 
-NOTE: Use of Docker images from other repositories is not yet supported.
-But you can load the official Docker images into a local Docker image cache if necessary.
+The repository used by the operator can be overridden to pull images from other repositories.
+This can be achieved by setting the `etcd-repository` flag on the manager, for example `--etcd-repository=gcr.io/etcd-development/etcd`.
 
 The `etcd-cluster-operator` will use the supplied `version` value to compute a Docker image name
 which is then used by the Pods for each Etcd peer.


### PR DESCRIPTION
Closes https://github.com/improbable-eng/etcd-cluster-operator/issues/187

## Changes

Adds a `--etcd-repository` flag to the manager to allow overriding the default `quay.io/coreos/etcd` repository.

## Verification

Running `make e2e-kind` with `config/manager/manager.yaml` set to

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: controller-manager
  namespace: system
  labels:
    control-plane: controller-manager
spec:
  selector:
    matchLabels:
      control-plane: controller-manager
  replicas: 1
  template:
    metadata:
      labels:
        control-plane: controller-manager
    spec:
      containers:
      - command:
        - /manager
        args:
        - --enable-leader-election
        - --proxy-url=eco-proxy.eco-system.svc
        - --etcd-repository=gcr.io/etcd-development/etcd
        image: controller:latest
        name: manager
        resources:
          limits:
            cpu: 100m
            memory: 100Mi
          requests:
            cpu: 100m
            memory: 100Mi
      terminationGracePeriodSeconds: 10
```

The pods that were brought up used `gcr.io/etcd-development/etcd` as the repo.
```
$ kubectl describe pods --namespace teste2e-parallel-restore restored-cluster-1-6tz9l
Name:         restored-cluster-1-6tz9l
Namespace:    teste2e-parallel-restore
Priority:     0
Node:         etcd-e2e-control-plane/172.17.0.3
Start Time:   Thu, 28 May 2020 17:47:13 +0100
Labels:       app.kubernetes.io/name=etcd
              etcd.improbable.io/cluster-name=restored-cluster
              etcd.improbable.io/peer-name=restored-cluster-1
Annotations:  <none>
Status:       Running
IP:           10.244.0.41
IPs:
  IP:           10.244.0.41
Controlled By:  ReplicaSet/restored-cluster-1
Containers:
  etcd:
    Container ID:   containerd://83fc891c4be3a0e4bff44519ef9053dbb9936139aff0c3ba34a071968184a956
    Image:          gcr.io/etcd-development/etcd:v3.2.28
    Image ID:       gcr.io/etcd-development/etcd@sha256:d7e49cb2f859884cfb1f37ee1f5cb792affce0d40b487952c5d087c987c271a2
```