### PR TITLE
added missing permissions to the ClusterRole that are needed

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -110,12 +110,9 @@ rules:
   - etcd.improbable.io
   resources:
   - etcdclusters
+  - etcdclusters/finalizers
   verbs:
-  - create
-  - get
-  - list
-  - patch
-  - watch
+  - "*"
 - apiGroups:
   - etcd.improbable.io
   resources:
@@ -128,13 +125,9 @@ rules:
   - etcd.improbable.io
   resources:
   - etcdpeers
+  - etcdpeers/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
+  - "*"
 - apiGroups:
   - etcd.improbable.io
   resources:


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

The EtcdCluster and EtcdPeer instances were failing to create by the operator due to missing permissions in the ClusterRole. They have been addressed in this PR by adding the necessary permissions to the ClusterRole. 
Github Issue has been created few days before and I was able to fix it by following the google results - https://github.com/improbable-eng/etcd-cluster-operator/issues/191

## Verification
I tested it after adding these permissions and then operator was able to create instances of EtcdCluster and EtcdPeer. 
<!-- How you tested it? How do you know it works? -->
