### PR TITLE
Update installation instructions for kustomize v3

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -33,5 +33,5 @@ cd config/default
 export ECO_VERSION=v0.2.0
 kustomize edit set image controller=$ECO_VERSION
 kustomize edit set image proxy=$ECO_VERSION
-kubectl apply --kustomize .
+kustomize build . | kubectl apply -f -
 ```


### PR DESCRIPTION
kubectl uses kustomize v2, whereas our Makefile uses kustomize v3. This replaces the installation instructions to use the `kustomize build | kubectl apply -f -` pattern instead of kubectl's built in kustomize. 
