### PR TITLE
Make eco recognize podTemplate changes

### DIFF
--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -67,6 +67,7 @@ func (o *EtcdCluster) ValidateUpdate(old runtime.Object) error {
 	// Overwrite the fields which are allowed to change
 	oldO.Spec.Replicas = o.Spec.Replicas
 	oldO.Spec.Version = o.Spec.Version
+	oldO.Spec.PodTemplate = o.Spec.PodTemplate
 
 	if diff := cmp.Diff(oldO.Spec, o.Spec); diff != "" {
 		return fmt.Errorf("Unsupported changes: (- current, + new) %s", diff)

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -157,20 +157,6 @@ func TestEtcdCluster_ValidateUpdate(t *testing.T) {
 			err: "^Unsupported changes:",
 		},
 		{
-			// TODO Support pod annotation modification https://github.com/improbable-eng/etcd-cluster-operator/issues/109
-			name: "ModifyPodSpecAnnotation",
-			modifier: func(o *v1alpha1.EtcdCluster) {
-				o.Spec.PodTemplate = &v1alpha1.EtcdPodTemplateSpec{
-					Metadata: &v1alpha1.EtcdPodTemplateObjectMeta{
-						Annotations: map[string]string{
-							"new-annotation": "some-value",
-						},
-					},
-				}
-			},
-			err: "^Unsupported changes:",
-		},
-		{
 			name: "UnsupportedChange/StorageClassName",
 			modifier: func(o *v1alpha1.EtcdCluster) {
 				*o.Spec.Storage.VolumeClaimTemplate.StorageClassName += "-changed"


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

- Allow podTemplate changes which are handled like version upgrades with a rolling re-deployment
cycle of all etcd members.
<!-- Enumerate changes you made -->

## Verification

- Verified on a tests cluster that I could update podTemplates with new configurations such as anti-affinity, resource requests and limits. (verified with single-node and multi-node cluster)
- Also verified that version upgrades still work as before.

Refs #109 (but solved in a more generic way)